### PR TITLE
Bunch of changes to make more mobile-first

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="dark" data-style="original">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,17 +11,48 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.js"></script>
 
     <style>
+        /* 
+           THEME CONFIGURATION
+           We use data-theme for Pico's base (light/dark) and data-style for specific color palettes/fonts.
+           
+           To add a new theme:
+           1. Define a new [data-style="theme-name"] block here with your overrides.
+              - --pico-primary: Main accent color
+              - --pico-primary-background: Background for buttons/badges
+              - --pico-primary-hover: Hover state color
+              - --pico-primary-underline: Underline color
+              - --pico-font-family: Optional font override (default is sans-serif)
+           2. Update the `themes` object in script.js `applyTheme()` function.
+           3. Add the option to the Theme Selector in script.js `renderSettingsUI()`.
+        */
+        
+        /* Base Settings (Global) */
         :root {
+             /* Mobile-first: Increase base size for better legibility by default */
+            --pico-font-size: 110%;
+        }
+
+        /* THEME: Original (Blue Accent) */
+        [data-style="original"] {
             /* IntelliJ/Solarized inspired blue accent */
             --pico-primary: #3b82f6;
             --pico-primary-background: #3b82f6;
             --pico-primary-hover: #2563eb;
             --pico-primary-underline: rgba(59, 130, 246, 0.5);
-            
-            /* Mobile-first: Increase base size for better legibility by default */
-            --pico-font-size: 110%;
         }
-        
+
+        /* 
+           FUTURE THEME EXAMPLES:
+           
+           [data-style="crimson"] {
+               --pico-primary: #c62828;
+               --pico-primary-background: #c62828;
+               --pico-primary-hover: #b71c1c;
+               --pico-primary-underline: rgba(198, 40, 40, 0.5);
+               --pico-font-family: "Georgia", "Times New Roman", serif; 
+           }
+        */
+
         /* Enable word-wrapping for Pico CSS tooltips */
         [data-tooltip]::before {
             display: block;


### PR DESCRIPTION
Rewrote the CSS to be more mobile-first and fixed the various text font size problems and CSS conflicts. Also put in the start of the theme system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major UI/UX pass emphasizing mobile-first responsiveness and basic theming.
> 
> - CSS overhaul: mobile-first `song-card` layout (stacked on mobile, horizontal on ≥577px), larger touch targets/typography, responsive header, wider containers on desktop, and mobile modal fixes
> - Theme system: new `data-style` attribute, `applyTheme()` with mapped themes, theme persisted in URL (`theme` param) and selectable in Settings; default `original-dark`
> - Stats modal: replaces HTML table with `.contributions-table` responsive grid; rank display now `#<rank>` (or `👻` for shadow ranks) with improved tooltips
> - Minor UI tweaks: adjusted `lite-youtube` play button behavior, improved source list readability, and responsive two-column `.column-list` on ≥768px
> - URL sync: `updateURL()` and `syncStateFromURL()` extended to include theme; `updateSetting()` handles theme changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63724ca1cda4fd1a18b452f8b589a04a778df94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->