### PR TITLE
iPhone 15 pro display

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@
         }
 
         /* Remove card styling from nested articles to regain horizontal space */
-        dialog article article {
+        dialog article article:not(.mode-card) {
           padding: 0;
           background: transparent;
           box-shadow: none;
@@ -580,7 +580,7 @@
           padding-bottom: 1.5rem;
         }
 
-        dialog article article:last-of-type {
+        dialog article article:not(.mode-card):last-of-type {
           border-bottom: none;
           margin-bottom: 0;
           padding-bottom: 0;


### PR DESCRIPTION
Scope mobile-only CSS rule for nested articles in dialogs to prevent it from stripping styling from `.mode-card` elements.

The existing mobile-only rule for nested articles in dialogs was unintentionally applying to `.mode-card` elements (like the decay mode cards), causing their active borders to be replaced and appear clipped on iPhone viewports.

---
<a href="https://cursor.com/background-agent?bcId=bc-25a7dc4b-fac2-44b5-ae08-cff0b088a4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25a7dc4b-fac2-44b5-ae08-cff0b088a4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

