### PR TITLE
Apple music link integration

### DIFF
--- a/script.js
+++ b/script.js
@@ -310,6 +310,7 @@ function render() {
         if (song.media?.youtube?.video_id) links.push(`<li><a href="https://www.youtube.com/watch?v=${song.media.youtube.video_id}" target="_blank">YouTube</a></li>`);
         if (song.media?.youtube?.music_id) links.push(`<li><a href="https://music.youtube.com/watch?v=${song.media.youtube.music_id}" target="_blank">YTM</a></li>`);
         if (song.media?.spotify?.id) links.push(`<li><a href="https://open.spotify.com/track/${song.media.spotify.id}" target="_blank">Spotify</a></li>`);
+        if (song.media?.apple?.url) links.push(`<li><a href="${song.media.apple.url}" target="_blank">Apple</a></li>`);
         if (song.media?.bandcamp?.url) links.push(`<li><a href="${song.media.bandcamp.url}" target="_blank">Bandcamp</a></li>`);
         if (song.media?.other?.url) links.push(`<li><a href="${song.media.other.url}" target="_blank">Other</a></li>`);
 


### PR DESCRIPTION
Add Apple Music link to song cards to allow users to listen to songs on Apple Music when data is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-22858327-05c9-4e8d-a3cb-61eaf70dc475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22858327-05c9-4e8d-a3cb-61eaf70dc475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

