### PR TITLE
Add genre display to song cards

### DIFF
--- a/data.json
+++ b/data.json
@@ -354,9 +354,7 @@
                     "id": "2SsY5k7UWFqgye3PUMG3Oq"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBAYE2500026",
@@ -444,9 +442,7 @@
                     "id": "1WmBVbFmLt0w6zPP37TeCG"
                 }
             },
-            "genres": [
-                "Bedroom Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USUM72412581",
@@ -532,9 +528,7 @@
                     "id": "2LHNTC9QZxsL3nWpt8iaSR"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBUM72503089",
@@ -614,9 +608,7 @@
                     "id": "1qbmS6ep2hbBRaEZFpn7BX"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop Soul"
         },
         {
             "id": "USAT22504344",
@@ -687,10 +679,7 @@
                     "id": "0bxPRWprUVpQK0UFcddkrA"
                 }
             },
-            "genres": [
-                "Contemporary R&B",
-                "R&B/Soul"
-            ]
+            "genres": "Contemporary R&B"
         },
         {
             "id": "QZ8BZ2513510",
@@ -756,10 +745,7 @@
                     "id": "1CPZ5BxNNd0n0nF4Orb9JS"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "USSM12504034",
@@ -825,10 +811,7 @@
                     "id": "2T8yuUKl1nhmtaIocqWo4i"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "QMFMF2447057",
@@ -889,9 +872,7 @@
                     "id": "2lTm559tuIvatlT1u0JYG2"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "QZVM32200357",
@@ -959,9 +940,7 @@
                     "url": "https://oklou.bandcamp.com/track/blade-bird"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USUM72504354",
@@ -1032,9 +1011,7 @@
                     "id": "42UBPzRMh5yyz0EDPr6fr1"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USSM12501184",
@@ -1100,9 +1077,7 @@
                     "id": "3H6xZgwRZx8McVUJzmMxWe"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMFME2535037",
@@ -1172,9 +1147,7 @@
                     "id": "55lijDD6OAjLFFUHU9tcDm"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USWB12502589",
@@ -1245,10 +1218,7 @@
                     "id": "6qR5YGunNSASaabs4kJB9V"
                 }
             },
-            "genres": [
-                "Contemporary R&B",
-                "R&B/Soul"
-            ]
+            "genres": "Contemporary R&B"
         },
         {
             "id": "GBUM72501035",
@@ -1314,9 +1284,7 @@
                     "id": "1FlDLGaTsr9HH1zfJiq6is"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "FR59R2505163",
@@ -1371,9 +1339,7 @@
                     "id": "4YDl2Oxc1mVRnZsZAbNzI0"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USRC12403580",
@@ -1439,9 +1405,7 @@
                     "id": "2zOmS55knKWSgScYPTNmGQ"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USBQU2500085",
@@ -1495,9 +1459,7 @@
                     "url": "https://geesebandnyc.bandcamp.com/track/taxes"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USJ5G2542802",
@@ -1550,9 +1512,7 @@
                     "url": "https://wednesdayband.bandcamp.com/track/townies"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "GB5KW2501372",
@@ -1613,9 +1573,7 @@
                     "id": "73vfMXcXa6iY1E3lpf2fZO"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USMTD2400372",
@@ -1662,9 +1620,7 @@
                     "id": "2UYuux157cn498H23UfHQf"
                 }
             },
-            "genres": [
-                "Art Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USRC12500402",
@@ -1728,9 +1684,7 @@
                     "url": "https://sandy.bandcamp.com/track/afterlife"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12504327",
@@ -1781,9 +1735,7 @@
                     "id": "7iYrk5G9jTqY5oG8k7Lj0B"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alt\u00e9"
         },
         {
             "id": "USUG12506174",
@@ -1829,9 +1781,7 @@
                     "id": "29iva9idM6rFCPUlu7Rhxl"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMFMF2447070",
@@ -1886,9 +1836,7 @@
                     "id": "3sK8wGT43QFpWrvNQsrQya"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "GBLZC2400049",
@@ -1942,10 +1890,7 @@
                     "url": "https://aya-yco.bandcamp.com/track/off-to-the-esso"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Experimental"
         },
         {
             "id": "USLD91772032",
@@ -1991,9 +1936,7 @@
                     "id": "2u9S9JJ6hTZS3Vf22HOZKg"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "QZES62549912",
@@ -2034,10 +1977,7 @@
                     "id": "5uz5v1hRZLjNGatcPtOWUv"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "GBCVZ2500003",
@@ -2097,10 +2037,7 @@
                     "url": "https://pulpmusic.bandcamp.com/track/spike-island"
                 }
             },
-            "genres": [
-                "Britpop",
-                "Madchester"
-            ]
+            "genres": "Britpop"
         },
         {
             "id": "USJ5G2542804",
@@ -2151,9 +2088,7 @@
                     "id": "00lSB9CSyOcsxKVtbPbniL"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "DEG932501778",
@@ -2201,9 +2136,7 @@
                     "url": "https://jameskmusic.bandcamp.com/track/play"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "USBQU2400171",
@@ -2254,9 +2187,7 @@
                     "id": "2zf1izCOz2F22PF27uhxRF"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBBKS2500041",
@@ -2349,9 +2280,7 @@
                     "id": "5TFD2bmFKGhoCRbX61nXY5"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "USA2P2520537",
@@ -2392,10 +2321,7 @@
                     "id": "1IXWSLygPDS5LQDQZH0NAz"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USSM12504190",
@@ -2441,9 +2367,7 @@
                     "id": "65DbTqJKhbwqYbZ1Okr0rc"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USSM12501572",
@@ -2489,9 +2413,7 @@
                     "id": "7B3BwNecBhKvNwSMOOl7Gk"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUG12504304",
@@ -2537,9 +2459,7 @@
                     "id": "5BZsQlgw21vDOAjoqkNgKb"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBARL2500465",
@@ -2585,9 +2505,7 @@
                     "id": "5v5ESV1s4Y964nDJdxb2s4"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUG12408496",
@@ -2628,9 +2546,7 @@
                     "id": "2CGNAOSuO1MEFCbBRgUzjd"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip Hop"
         },
         {
             "id": "USUM72503410",
@@ -2666,9 +2582,7 @@
                     "id": "1j15Ar0qGDzIR0v3CQv3JL"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "QZVM32200403",
@@ -2714,9 +2628,7 @@
                     "id": "37Dsnkoxh3zFRcEwZAOIBg"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "GBBKS2500077",
@@ -2794,9 +2706,7 @@
                     "id": "2GFawZaMjG8QLxiR4OD3db"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QZS7J2542546",
@@ -2842,10 +2752,7 @@
                     "id": "0QCIpQV3twfqo9kh0t8Zza"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Alt\u00e9"
         },
         {
             "id": "QZES52538872",
@@ -2891,9 +2798,7 @@
                     "id": "4eULTkHVLAhn5J5DOSNbdP"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBBKS2500053",
@@ -2975,9 +2880,7 @@
                     "id": "0xaQ86cGRgcF8wwP1SkXsb"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "USSM12502221",
@@ -3028,9 +2931,7 @@
                     "id": "7N1GSHGlLwXY3lN5gv3QLV"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "FRX452505206",
@@ -3076,10 +2977,7 @@
                     "id": "7HWDQfrQvnAXp5Xk29xqh7"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
             "id": "US3R42550302",
@@ -3128,10 +3026,7 @@
                     "url": "https://mommaband.bandcamp.com/track/i-want-you-fever"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "GBCEL2400962",
@@ -3182,9 +3077,7 @@
                     "id": "5UW4tA4j23YL6kDfRw3rWT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USWB12502453",
@@ -3240,10 +3133,7 @@
                     "id": "05od2qm2MTSKCHxy1GBp5W"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "QMB622500153",
@@ -3284,9 +3174,7 @@
                     "id": "4cSeIOmk8tffkGPYavEp57"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBBKS2500311",
@@ -3373,10 +3261,7 @@
                     "id": "0XWCzu4SUFz2jusWBPrDvU"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "USQX92503270",
@@ -3432,10 +3317,7 @@
                     "id": "6xV7Be6XEvkSnighmh2Tzj"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "USUM72502314",
@@ -3471,9 +3353,7 @@
                     "id": "4zK082ykqJzJGzC64NXjp1"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "QZAZS2410812",
@@ -3509,9 +3389,7 @@
                     "id": "2aFkH4wK9nZbgtmlq411f2"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USSM12504030",
@@ -3547,10 +3425,7 @@
                     "id": "4ORvXsPK9AJmDzm36BYcdy"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "NLA322500073",
@@ -3586,9 +3461,7 @@
                     "id": "0k9JIBszlCqCa4SpXI353F"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "USSM12504044",
@@ -3619,10 +3492,7 @@
                     "id": "7o76sIawH9bRWsltcWfQfd"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "QZD442001485",
@@ -3662,9 +3532,7 @@
                     "id": "3znSvEwBq09We4cxxmwlZM"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "QM7282558733",
@@ -3705,9 +3573,7 @@
                     "id": "4Ozk6GESL4KkJ0C1yXgDLf"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "GBCVZ2400262",
@@ -3753,10 +3619,7 @@
                     "url": "https://caroline.bandcamp.com/track/total-euphoria"
                 }
             },
-            "genres": [
-                "Slowcore",
-                "Post-Rock"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "USAT22504687",
@@ -3792,9 +3655,7 @@
                     "id": "4JI9FH3KOYOushudtnZt0z"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USSM12501674",
@@ -3830,9 +3691,7 @@
                     "id": "1WBD2KNkYu880G7ElAituh"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "UK7MC2500274",
@@ -3874,9 +3733,7 @@
                     "id": "168GHxsiJyT9tlJN74ZO11"
                 }
             },
-            "genres": [
-                "Swedish Pop"
-            ]
+            "genres": "Swedish Pop"
         },
         {
             "id": "USUG12503807",
@@ -3907,9 +3764,7 @@
                     "id": "4n4tC4qO2LeWQRM9Gbbtop"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USUM72501138",
@@ -3945,9 +3800,7 @@
                     "id": "18DEvCPCmzVpo2en9DeylA"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USMTD2400678",
@@ -4035,9 +3888,7 @@
                     "id": "5yz4ZfLeZ3VdqDM2l8wjjg"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USAT22404700",
@@ -4073,10 +3924,7 @@
                     "id": "536rHxlVFXGJBO2xWE7HsV"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USRC12500972",
@@ -4107,9 +3955,7 @@
                     "id": "03JZr55j9bIj1d2RQJ7Yq9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USRC12500673",
@@ -4145,10 +3991,7 @@
                     "id": "1XMBjGYUakFEjI4ZaISVt2"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USRC12500017",
@@ -4179,10 +4022,7 @@
                     "id": "1QrbZhFYlViXd60g130vw1"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Progressive Metal"
         },
         {
             "id": "USSM12501019",
@@ -4218,9 +4058,7 @@
                     "id": "5SxahezRlC0saXbCALfB7c"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBBKS2500056",
@@ -4293,9 +4131,7 @@
                     "id": "5iALdwbhnUHa8zGStA3h1J"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "DEG932501186",
@@ -4331,10 +4167,7 @@
                     "id": "18cS2gM9O0jkVYCBuMsBLq"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "USUG12500650",
@@ -4375,9 +4208,7 @@
                     "id": "1musbempyJAw5gfSKZHXP9"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QM4TW2517490",
@@ -4413,10 +4244,7 @@
                     "id": "3m9g8ua3M51JvqmS8rh6bS"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "QZVEM2532603",
@@ -4457,9 +4285,7 @@
                     "id": "6sRu3Bf5hxIRCQ8XGfYv1c"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "GBAFL2400208",
@@ -4491,9 +4317,7 @@
                     "id": "5Pr0dZZjoGqnWzlASF1ESU"
                 }
             },
-            "genres": [
-                "Dream Pop"
-            ]
+            "genres": "Dream Pop"
         },
         {
             "id": "USUG12506436",
@@ -4524,9 +4348,7 @@
                     "id": "53iuhJlwXhSER5J2IYYv1W"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "US38Y2445002",
@@ -4557,9 +4379,7 @@
                     "id": "4XosapYiYaXGcxc83p3DD9"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6MZ2547404",
@@ -4595,10 +4415,7 @@
                     "id": "22vRKcdPjVW7Q6ydLNcYBV"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "QM6MZ2547406",
@@ -4634,10 +4451,7 @@
                     "id": "3zTqj90l1JdCzBBhxk5Z7U"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "QT3F42457524",
@@ -4678,9 +4492,7 @@
                     "id": "7HDq8aEtkBeZq7gfzYjW28"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "US2U62539801",
@@ -4723,10 +4535,7 @@
                     "url": "https://feeblelittlehorse.bandcamp.com/track/this-is-real"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USUG12504962",
@@ -4757,9 +4566,7 @@
                     "id": "4SC29UjZqGD3DaZNipthGk"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alt\u00e9"
         },
         {
             "id": "USUG12501598",
@@ -4795,9 +4602,7 @@
                     "id": "5xHgo5JN0wfsV41HnRaos5"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USD8D2528004",
@@ -4838,10 +4643,7 @@
                     "id": "0pfH12vOqokHreQwW5fItt"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Indie Electronic"
         },
         {
             "id": "USUM72507827",
@@ -4877,9 +4679,7 @@
                     "id": "3qrht50EwYuMgjPkM2A3aJ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Baroque Pop"
         },
         {
             "id": "USBQU2500083",
@@ -4910,9 +4710,7 @@
                     "id": "1g9GiiPPaL7KcDHlDzu7lT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USAT22508691",
@@ -4948,9 +4746,7 @@
                     "id": "6lYUgmE829m06SMC6tG3qD"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USWB12501004",
@@ -4985,9 +4781,7 @@
                     "id": "7sam5WsFimXgFOCuEOc90x"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "GXHAF2589304",
@@ -5020,9 +4814,7 @@
                     "url": "https://armandhammer.bandcamp.com/track/dogeared-feat-kapwani"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USAT22507194",
@@ -5053,9 +4845,7 @@
                     "id": "5AzO8bswSqsYtJIfVA2BqX"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USUG12500830",
@@ -5086,9 +4876,7 @@
                     "id": "41YlWhySoJVw2TXaxW1q5G"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "QZZ4J2500216",
@@ -5119,9 +4907,7 @@
                     "id": "4JxgNwic9PMF1c87TKWZOr"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "USUG12502630",
@@ -5147,9 +4933,7 @@
                     "id": "6Sv0CzVqzydd7NYQgAG70c"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "USRE12500231",
@@ -5175,9 +4959,7 @@
                     "id": "4JV3BjszeEUD1bTTcx9hdx"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Nu Metal"
         },
         {
             "id": "QZJ842503224",
@@ -5207,9 +4989,7 @@
                     "id": "7kQSYTf3fA2DYl4NbTzSzS"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "QZTAW2567571",
@@ -5240,9 +5020,7 @@
                     "id": "4Ji5pXYxvpxIAR87YGGx3Q"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZD442001491",
@@ -5273,9 +5051,7 @@
                     "id": "6X5sXeRwqbqPsZ8FFFae0F"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "QM7282516248",
@@ -5306,9 +5082,7 @@
                     "id": "02kTd6gB8IsBwPygDTHE4c"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "GBAYE2500032",
@@ -5334,9 +5108,7 @@
                     "id": "5QCfOMH5K7bS4dH7H7PNeI"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USUG12501593",
@@ -5372,9 +5144,7 @@
                     "id": "46bUjfJt7SVePcWtBVKa7W"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "UKQNV2500087",
@@ -5405,9 +5175,7 @@
                     "id": "7DigNxE6prVBzj4sPJopkT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBCVZ2400264",
@@ -5435,10 +5203,7 @@
                     "id": "0p6WXZoqJ3eoV6G9WtL0o3"
                 }
             },
-            "genres": [
-                "Slowcore",
-                "Post-Rock"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "GBAYE2501217",
@@ -5476,9 +5241,7 @@
                     "id": "1DwscornXpj8fmOmYVlqZt"
                 }
             },
-            "genres": [
-                "Bedroom Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USBQU2400298",
@@ -5514,9 +5277,7 @@
                     "id": "1KuJP2mJPtCXe1aeXXPvSP"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSM12501573",
@@ -5547,9 +5308,7 @@
                     "id": "01fzY6YKwKQ3LxCpIP6buB"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM6P42585436",
@@ -5580,9 +5339,7 @@
                     "id": "7GRPnTVWiFqlC3EAvFiKvY"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUG12405664",
@@ -5613,9 +5370,7 @@
                     "id": "1eTaznNW4Xxtx9za2SMTXB"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "OTHER:https://chuquimamani-condori.bandcamp.com/track/breathe-kullawada-caporal-e-dj-edit",
@@ -5669,10 +5424,7 @@
                     "id": "04KHyqdGs5sVEWX6UnukF2"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USUG12506371",
@@ -5703,10 +5455,7 @@
                     "id": "04yGQ4xzVt9LVAqop42ja6"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "USMRG2586908",
@@ -5736,10 +5485,7 @@
                     "id": "0UF9UVGNlZ12xDzzhjOrRd"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBUM72503351",
@@ -5775,9 +5521,7 @@
                     "id": "39js1Jxh1R29ht4mAvTdBr"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUM72504443",
@@ -5813,9 +5557,7 @@
                     "id": "4SRShYMtFIGgnOU7iBicMH"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUM72508238",
@@ -5841,9 +5583,7 @@
                     "id": "2mNGL7mZILSqZHxGboJaO9"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "GBAHS2500558",
@@ -5874,9 +5614,7 @@
                     "id": "1lbNgoJ5iMrMluCyhI4OQP"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Stutter House"
         },
         {
             "id": "USWB12405502",
@@ -5907,10 +5645,7 @@
                     "id": "7qjZnBKE73H4Oxkopwulqe"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USUG12409104",
@@ -5941,9 +5676,7 @@
                     "id": "4VhbsGXRGDncpi79aiX8eE"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZQAY2543218",
@@ -5969,10 +5702,7 @@
                     "id": "55NuTxRk1TyKzpgD8dC1IY"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Dance"
-            ]
+            "genres": "Jersey Club"
         },
         {
             "id": "UKXN22549553",
@@ -6007,9 +5737,7 @@
                     "id": "77VBQKutkIrMfr7PPvZWdA"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USAT22404703",
@@ -6045,9 +5773,7 @@
                     "id": "1CqyErlQstROOe9hAn93oI"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USRC12500851",
@@ -6078,9 +5804,7 @@
                     "id": "0x5wJ0cDp7miv49jSMTSkq"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USAT22504013",
@@ -6110,9 +5834,7 @@
                     "id": "4kUI0vuDd0Zub4IvxxNreM"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Soft Pop"
         },
         {
             "id": "USUM72500706",
@@ -6143,9 +5865,7 @@
                     "id": "2J051fjLklkoPbzOoTAACZ"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "GBUM72502230",
@@ -6181,9 +5901,7 @@
                     "id": "7gKxCvTDWwV9wBhdeBbr3l"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop Soul"
         },
         {
             "id": "NZUM72500008",
@@ -6219,9 +5937,7 @@
                     "id": "7hGCCQkdyF1MX6uk339uBS"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USA2P2516245",
@@ -6247,10 +5963,7 @@
                     "id": "2I9517MJ7979KTtFjbDo5E"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Chicago Drill"
         },
         {
             "id": "USA5W2500030",
@@ -6276,9 +5989,7 @@
                     "id": "4cLC8gydI0O78g8chZugS4"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Worship"
         },
         {
             "id": "US38Y2445006",
@@ -6304,9 +6015,7 @@
                     "id": "5Lf2llKUYgSakzMejYowOu"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "NL8RL2462615",
@@ -6345,9 +6054,7 @@
                     "url": "https://janeremover.bandcamp.com/track/jrjrjr"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USRC12500621",
@@ -6388,9 +6095,7 @@
                     "id": "6ZAuQOgLrNQb9s7BXheuTy"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMB622406029",
@@ -6421,9 +6126,7 @@
                     "id": "65BLWgYIxnhe0GSSAt7laa"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USQX92503688",
@@ -6449,10 +6152,7 @@
                     "id": "555oowE8kujtS6bR2GOOPD"
                 }
             },
-            "genres": [
-                "Pop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "UKXN22549557",
@@ -6478,9 +6178,7 @@
                     "id": "1nyWOn19RBU0J9LIzgfNJK"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USWB12503072",
@@ -6506,10 +6204,7 @@
                     "id": "0XnD9GJRD01wvXFLWJXiYx"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Alternative"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USAT22501082",
@@ -6545,9 +6240,7 @@
                     "id": "4E0P1xs3JNmsNr5c5nFTZJ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "CA5KR2532448",
@@ -6572,10 +6265,7 @@
                     "id": "7sGYT6ewCCJ5KJvWP1n3MP"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USWB12503070",
@@ -6601,10 +6291,7 @@
                     "id": "6Qgy3ikLFnJsJ7xHL0mayF"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Alternative"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "GBBKS2500036",
@@ -6630,9 +6317,7 @@
                     "id": "5u7QDciPfgcpmoqRtp6zk6"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Neoperreo"
         },
         {
             "id": "NLA322500067",
@@ -6663,9 +6348,7 @@
                     "id": "4gM6AHXp4h8aj5482znmYz"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "US5022500033",
@@ -6696,10 +6379,7 @@
                     "id": "2RAKwOzLiXA8AgA1pFIuFe"
                 }
             },
-            "genres": [
-                "Latin",
-                "Alternative"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "KRA402400094",
@@ -6735,10 +6415,7 @@
                     "id": "5H1sKFMzDeMtXwND3V6hRY"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "OTHER:https://losthuthanaka.bandcamp.com/track/kullawada-awila",
@@ -6787,9 +6464,7 @@
                     "id": "7EW7Yivb93qKAtp5qEm5of"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Melodic Rap"
         },
         {
             "id": "YT:RylVTdo6sMc",
@@ -6822,9 +6497,7 @@
                     "url": "https://hotlinetnt.bandcamp.com/track/julias-war"
                 }
             },
-            "genres": [
-                "Shoegaze"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USRE12500236",
@@ -6855,9 +6528,7 @@
                     "id": "2463q6UN8BIDfeVI379qFz"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Nu Metal"
         },
         {
             "id": "USUG12506441",
@@ -6888,9 +6559,7 @@
                     "id": "62V2ZHslgQV98gH4AuVXnr"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZVM32200344",
@@ -6915,9 +6584,7 @@
                     "id": "7zyBL0LZndcnPXsbdhiqWp"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USAT22500052",
@@ -6943,9 +6610,7 @@
                     "id": "5nZ73ycbCA2lkEyuM1K6zB"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QZH6S1901073",
@@ -6971,9 +6636,7 @@
                     "id": "5ppdmIeHPG2qLHm0SsmqfB"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USQE92500121",
@@ -7004,9 +6667,7 @@
                     "id": "3hut1ozNEFwZ8W1rxATaH9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USEP42520002",
@@ -7037,9 +6698,7 @@
                     "id": "1KpAjuTO2M9eYnaGz6uoTc"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USQX92502794",
@@ -7070,10 +6729,7 @@
                     "id": "3McBKxKZLXbE4czUezk5QG"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Neo-Psychedelic"
         },
         {
             "id": "DED622500086",
@@ -7112,10 +6768,7 @@
                     "url": "https://safemind.bandcamp.com/track/standing-on-air"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Electronic"
-            ]
+            "genres": "Darkwave"
         },
         {
             "id": "USA2P2501009",
@@ -7146,9 +6799,7 @@
                     "id": "03gyVoP8A8A3mdcGMxcHqD"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QZLL92584883",
@@ -7179,10 +6830,7 @@
                     "id": "59F5qOMpqqclD21cIAxFEo"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Country"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "USUG12506438",
@@ -7213,9 +6861,7 @@
                     "id": "3yWuTOYDztXjZxdE2cIRUa"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM24S2501673",
@@ -7246,9 +6892,7 @@
                     "id": "75Wgg4LerPD3mVO5hEyUN9"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USUM72414866",
@@ -7279,9 +6923,7 @@
                     "id": "6iycYUk3oB0NPMdaDUrN1w"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "GBCKC2500057",
@@ -7312,9 +6954,7 @@
                     "id": "3KQFlED2WlEBOFRK61eI05"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Post-Rock"
         },
         {
             "id": "UKQNV2500021",
@@ -7339,9 +6979,7 @@
                     "id": "3W9INBEJLZwnBZlbGHz8P2"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GB5KW2501369",
@@ -7367,9 +7005,7 @@
                     "id": "6WQsY2YMdIQWoOm9MyZMWR"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "NLA322500053",
@@ -7405,9 +7041,7 @@
                     "id": "1zoXDi9AY4TF5JoUuCCTL6"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "USA2Z2500540",
@@ -7438,10 +7072,7 @@
                     "id": "1NoYnWzMQ1mY67jo7gDakq"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Black Metal"
         },
         {
             "id": "USA2Z2401959",
@@ -7475,10 +7106,7 @@
                     "url": "https://tobaccocity.bandcamp.com/track/autumn-2"
                 }
             },
-            "genres": [
-                "Americana",
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USUG12500209",
@@ -7504,9 +7132,7 @@
                     "id": "6gR9K14ED3UuhVIu4t9LTk"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBAYE2501216",
@@ -7529,9 +7155,7 @@
                     "id": "6EUjksHprxyLw7dbNZtACA"
                 }
             },
-            "genres": [
-                "Bedroom Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "FR9W12504836",
@@ -7562,10 +7186,7 @@
                     "id": "5sKMHfvZBvZAXWJLaoj5TI"
                 }
             },
-            "genres": [
-                "Electronic",
-                "IDM/Experimental"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "QZ9QQ2500158",
@@ -7601,10 +7222,7 @@
                     "id": "3hpm0fTeSqlhJbnqAgaLZs"
                 }
             },
-            "genres": [
-                "M\u00fasica Mexicana",
-                "Latin"
-            ]
+            "genres": "Corrido"
         },
         {
             "id": "NZUM72500023",
@@ -7635,9 +7253,7 @@
                     "id": "1gvOEwQbIEjkpLdcZwtBoB"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM6P42533258",
@@ -7668,9 +7284,7 @@
                     "id": "6M5Y8sn5cXePK58bH1WKon"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "QZTAY2562283",
@@ -7701,9 +7315,7 @@
                     "id": "3a3zDlE4bgI6ZvU00m6o84"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
             "id": "GBUM72501764",
@@ -7734,9 +7346,7 @@
                     "id": "6CYldrsUPBsiPtfLW4xZCl"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QT65X2524126",
@@ -7762,9 +7372,7 @@
                     "id": "5uGegogwUJ9g8caxaqVzoe"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Pop Singer-Songwriter"
         },
         {
             "id": "DEG932501948",
@@ -7789,10 +7397,7 @@
                     "id": "35TWPLjC6Iak3kAaA5yldE"
                 }
             },
-            "genres": [
-                "Folk",
-                "Alternative"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "QZZVQ2500049",
@@ -7818,9 +7423,7 @@
                     "id": "1HZECMqLKSh22jwPv3yRYm"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QMDA62527257",
@@ -7846,9 +7449,7 @@
                     "id": "712KzUVmtBeFXgJhbMJY5o"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Latin R&B"
         },
         {
             "id": "QMB622401121",
@@ -7874,9 +7475,7 @@
                     "id": "6gLOkCljeiC4m4bJj6BT8l"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBKZV2500021",
@@ -7907,9 +7506,7 @@
                     "id": "1EmJUalp1RWAHrmmqOYARH"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USSM12504032",
@@ -7935,10 +7532,7 @@
                     "id": "3hETtcSLmNncBjPMLHtVZs"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "USJ5G2542808",
@@ -7969,9 +7563,7 @@
                     "id": "5NRbeq1mnwgyWeVJzOivmT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QMRSZ2500157",
@@ -7997,9 +7589,7 @@
                     "id": "6zDsdi08Ym7zx7tjSilIks"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Neo Soul"
         },
         {
             "id": "QZWH32500403",
@@ -8025,10 +7615,7 @@
                     "id": "7u9dkCGGRSepXhCQUy3Nzm"
                 }
             },
-            "genres": [
-                "Traditional Country",
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QMB622406021",
@@ -8054,9 +7641,7 @@
                     "id": "0w3ptVGmlBJLWqwsrnrGnO"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "GBAJY2545703",
@@ -8082,10 +7667,7 @@
                     "id": "2yy0GLEoyeluaBXUJysaXE"
                 }
             },
-            "genres": [
-                "Classical",
-                "Piano"
-            ]
+            "genres": "Plunderphonics"
         },
         {
             "id": "MXA4B2500004",
@@ -8111,10 +7693,7 @@
                     "id": "5gGOOM1oDSQ59lcGOXIvZL"
                 }
             },
-            "genres": [
-                "M\u00fasica Mexicana",
-                "Latin"
-            ]
+            "genres": "Latin Folk"
         },
         {
             "id": "QZ2YT2500004",
@@ -8140,9 +7719,7 @@
                     "id": "4dUR3x8NPEgD2lvtavZp5p"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "GBCFB2401233",
@@ -8168,9 +7745,7 @@
                     "id": "5vkJZHiK2s7Os8AM1vInjv"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USJ5G2536510",
@@ -8196,9 +7771,7 @@
                     "id": "09I4z4KlAHUJcG9Atd9UvF"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUM72502732",
@@ -8224,9 +7797,7 @@
                     "id": "5Z4YeqJLy2Ik0NYr0xlfh7"
                 }
             },
-            "genres": [
-                "Jazz"
-            ]
+            "genres": "Experimental Jazz"
         },
         {
             "id": "QZDA82595300",
@@ -8252,10 +7823,7 @@
                     "id": "16cf5KXlcTvSpO1TisvQWI"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Alternative"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USAT22405547",
@@ -8281,9 +7849,7 @@
                     "id": "4OfDp6aSHjkeECflD1v82U"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USBQU2500076",
@@ -8309,9 +7875,7 @@
                     "id": "5WGr8oEBp2RBrorc5ZEx1K"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "QZ2YT2500011",
@@ -8342,9 +7906,7 @@
                     "id": "7Cx6yqhM7WSxrLMW2ZRulF"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "QMFMF2450864",
@@ -8375,10 +7937,7 @@
                     "id": "63QsCkpO2egX2zaqBAcyrh"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "US27Q2459508",
@@ -8404,10 +7963,7 @@
                     "id": "4KUd1EBo8cWkWsI3sdoZTy"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "USZXT2456171",
@@ -8433,9 +7989,7 @@
                     "id": "6CZUlSprqREfKDdmTxVkDx"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Lo-Fi House"
         },
         {
             "id": "USQX92503275",
@@ -8461,10 +8015,7 @@
                     "id": "5DRS7YEe1bwGJLDGviT3CD"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "USLD91772033",
@@ -8489,9 +8040,7 @@
                     "id": "0NUqi0ps17YpLUC3kgsZq0"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Dark R&B"
         },
         {
             "id": "USC4R2555760",
@@ -8522,9 +8071,7 @@
                     "id": "2UhaV3bOXEIzmbiVhnVZKY"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "GBK3W2403074",
@@ -8560,9 +8107,7 @@
                     "id": "29UD619bhwDjNXvuSh6cDz"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6MZ2547405",
@@ -8588,9 +8133,7 @@
                     "id": "6VXIZWHmdOTHIFhsSkYFgQ"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "KRA302500475",
@@ -8616,10 +8159,7 @@
                     "id": "6jYiHr12NVKLzn0X7K8aSK"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "US2J72507008",
@@ -8644,9 +8184,7 @@
                     "id": "0n1CfnJxvLVSVK4zAbuviH"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSM12500781",
@@ -8672,10 +8210,7 @@
                     "id": "3lGjhba2obegIC8Xc8VMK7"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "USUM72504449",
@@ -8705,9 +8240,7 @@
                     "id": "25jgQBxuUkGDdCG1WGKKN9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZNJW2532497",
@@ -8733,10 +8266,7 @@
                     "id": "72aGCwuSwD5Qb3tHvXBoX3"
                 }
             },
-            "genres": [
-                "Urbano latino",
-                "Latin"
-            ]
+            "genres": "Reggaeton Chileno"
         },
         {
             "id": "USAT22404707",
@@ -8762,10 +8292,7 @@
                     "id": "5kILHrfMHQ4eFHZqnu4yY3"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "CAZ8K2400013",
@@ -8793,10 +8320,7 @@
                     "url": "https://helenadeland.bandcamp.com/track/bigger-pieces"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative Folk"
         },
         {
             "id": "USBQU2500064",
@@ -8827,9 +8351,7 @@
                     "id": "7JfVH9o5zzVTKy5YcIYlfT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USWEX2400045",
@@ -8855,10 +8377,7 @@
                     "id": "5rO4yGfig3G1OeHWXf5uy5"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Ambient"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "UKN6K2403465",
@@ -8884,9 +8403,7 @@
                     "id": "54EUn24yXGAJ8AloharkT7"
                 }
             },
-            "genres": [
-                "Reggae"
-            ]
+            "genres": "Dub"
         },
         {
             "id": "NL3U12500034",
@@ -8912,9 +8429,7 @@
                     "id": "7ocARHwG3dk089ujfdowzJ"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Experimental"
         },
         {
             "id": "USAT22500349",
@@ -8945,9 +8460,7 @@
                     "id": "5sE9XpE2ukIwC2sYhIvUrs"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "USRC12500847",
@@ -8973,9 +8486,7 @@
                     "id": "6b77gsnwtmE0mY1Xkv3Tyn"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "GBBKS2400372",
@@ -9003,9 +8514,7 @@
                     "id": "1NQn6ovexeHuKcEMVfvb30"
                 }
             },
-            "genres": [
-                "Post-Punk"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "USBQU2500086",
@@ -9036,9 +8545,7 @@
                     "id": "1oevydxCBM8J6aGHKymgl1"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USRC12500056",
@@ -9069,9 +8576,7 @@
                     "id": "5W67A7t9MWL3VtovrVrici"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "UK R&B"
         },
         {
             "id": "USC4R2556359",
@@ -9105,9 +8610,7 @@
                     "url": "https://militariegun.bandcamp.com/track/b-a-d-i-d-e-a"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6P42533253",
@@ -9132,9 +8635,7 @@
                     "id": "3iewIkYTvvaicW8iysqxuU"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "QMB622506101",
@@ -9165,10 +8666,7 @@
                     "id": "0CO8FICjkvVDekOcarbvIR"
                 }
             },
-            "genres": [
-                "Country",
-                "Rock"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USUG12505004",
@@ -9194,9 +8692,7 @@
                     "id": "3eLxZnelhb4GtTdbqeW78b"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "New York Drill"
         },
         {
             "id": "QMB622500163",
@@ -9222,9 +8718,7 @@
                     "id": "2FFXU4b8sIsiLiTo6EWO19"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBUMC2500011",
@@ -9250,9 +8744,7 @@
                     "id": "1XhuLzTH3GGF7wAyQDorZf"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "GBCFB2401391",
@@ -9282,9 +8774,7 @@
                     "id": "5FGMhsO9YBSakTgNX2rhFj"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USRO22505073",
@@ -9320,10 +8810,7 @@
                     "id": "7zW1oZZy5m8zpJZfRfwGKv"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Bluegrass"
         },
         {
             "id": "QMDA72558184",
@@ -9354,9 +8841,7 @@
                     "id": "1Z1TErSXbCXjEJWKqcpf3V"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Old School Hip Hop"
         },
         {
             "id": "NLA322500061",
@@ -9378,10 +8863,7 @@
                     "id": "4UI693m28NeH4uY0mnBV0F"
                 }
             },
-            "genres": [
-                "Hardcore Punk",
-                "Hardcore"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "USRC12501799",
@@ -9407,9 +8889,7 @@
                     "id": "5T0mnzMsyHtmWB7Kou51Ph"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZRD92507374",
@@ -9435,9 +8915,7 @@
                     "id": "31XmjiAkFQmFxWJNbyTuQH"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USUM72503465",
@@ -9468,9 +8946,7 @@
                     "id": "1xOqGUkyxGQRdCvGpvWKmL"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "USQX92500261",
@@ -9501,10 +8977,7 @@
                     "id": "0fK7ie6XwGxQTIkpFoWkd1"
                 }
             },
-            "genres": [
-                "Pop",
-                "K-Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "GBBKS2500086",
@@ -9527,10 +9000,7 @@
                     "id": "5z46Jo6PQMz2kDmJuKknhV"
                 }
             },
-            "genres": [
-                "Techno",
-                "Idm"
-            ]
+            "genres": "Techno"
         },
         {
             "id": "USA2P2514520",
@@ -9561,10 +9031,7 @@
                     "id": "06ZX08uRQDK02emdw9mN28"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "QZS7J2540815",
@@ -9590,10 +9057,7 @@
                     "id": "16EwipmNxKwHngBBwu6s8V"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Pop"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "YT:v6dCTnnoVsI",
@@ -9643,9 +9107,7 @@
                     "id": "0xrF5God3TXbCml7bEnMBq"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "QM4TW2517487",
@@ -9675,10 +9137,7 @@
                     "id": "20kfSemlOU2CpCmh7GRSRv"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "USRE12500232",
@@ -9709,9 +9168,7 @@
                     "id": "3txlvthoUa9vWvG1zr2Lnr"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Nu Metal"
         },
         {
             "id": "USAT22504362",
@@ -9742,9 +9199,7 @@
                     "id": "3cZajhyr8LmtPfHZ9296tj"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Stutter House"
         },
         {
             "id": "GBARL2500423",
@@ -9770,9 +9225,7 @@
                     "id": "2piywRQIsqCM9cei6ZYTkl"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie"
         },
         {
             "id": "GBLZC2500020",
@@ -9800,9 +9253,7 @@
                     "url": "https://burial.bandcamp.com/track/imaginary-festival"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "US39N2515877",
@@ -9828,9 +9279,7 @@
                     "id": "0cAFtuZPD4sKl0X1R3dFin"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "QZVM32200450",
@@ -9856,9 +9305,7 @@
                     "id": "5ksAnx6NyYbHMQhEI7Y07B"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USBQU2400172",
@@ -9884,9 +9331,7 @@
                     "id": "6nUPcVDYjCrnNMaXAJ9eO3"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12502486",
@@ -9917,9 +9362,7 @@
                     "id": "5Ha86zPip9CSUj8hB61yUi"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "US6PQ2500017",
@@ -9950,10 +9393,7 @@
                     "id": "6CwycpWoVoUfZF5F7stEC2"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Pop"
-            ]
+            "genres": "Experimental"
         },
         {
             "id": "USRC12403826",
@@ -9983,9 +9423,7 @@
                     "id": "3U3hFkMr0Q90pD24EkE3Pr"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B"
         },
         {
             "id": "USUM72504847",
@@ -10011,9 +9449,7 @@
                     "id": "2N6md2JtrNake4sJ14KJ72"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USSM12500364",
@@ -10039,9 +9475,7 @@
                     "id": "7KwPWmB1gA9zRubseJ7OB2"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QT3F22563070",
@@ -10088,9 +9522,7 @@
                     "id": "5kCWzxtf36Zooj51yL66Bt"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Neo-Psychedelic"
         },
         {
             "id": "USAT22500015",
@@ -10116,10 +9548,7 @@
                     "id": "24RP8LdRXT4Om2NxZ0R7OS"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Black Metal"
         },
         {
             "id": "SE5AJ2202603",
@@ -10145,10 +9574,7 @@
                     "id": "1RDzKhuTUKoGZ0XVnnyyxQ"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Neofolk"
         },
         {
             "id": "QM6N22591382",
@@ -10177,9 +9603,7 @@
                     "url": "https://ninajirachi.bandcamp.com/album/fuck-my-computer"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USJ5G2442507",
@@ -10210,9 +9634,7 @@
                     "id": "02olsPYJypEE0IyuaGS4K4"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USMTD2400673",
@@ -10266,10 +9688,7 @@
                     "url": "https://shottatapes.bandcamp.com/track/l-i-h-t-feat-adam-sinclaire"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Folk"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "USUG12504960",
@@ -10300,9 +9719,7 @@
                     "id": "3S1fiHR7CUe9Nqa8h4H0u4"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alt\u00e9"
         },
         {
             "id": "USRC12501603",
@@ -10333,10 +9750,7 @@
                     "id": "26RtX0MphIh9C7ZWJEogJL"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USQE92500248",
@@ -10367,9 +9781,7 @@
                     "id": "5BDo6TzD8q0oNtqhhXU3nx"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USMTD2400407",
@@ -10397,9 +9809,7 @@
                     "id": "27Xxf6AtaSpXE47Xzvua9r"
                 }
             },
-            "genres": [
-                "Ambient Folk"
-            ]
+            "genres": "Ambient Folk"
         },
         {
             "id": "GBUM72503308",
@@ -10425,9 +9835,7 @@
                     "id": "7MZHqgTVTnN6xZGYAcEEAf"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USAT22412094",
@@ -10453,10 +9861,7 @@
                     "id": "3yhEwhpcoymynMjDbIzoTp"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Folk"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12506957",
@@ -10482,9 +9887,7 @@
                     "id": "7kw7I7P3MmYKfD4a4bf41l"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "QMFMF2447068",
@@ -10510,9 +9913,7 @@
                     "id": "1Hg0e997pObvZ91w1FCPFk"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "GBJCP2528901",
@@ -10538,10 +9939,7 @@
                     "id": "0G6UcQICO9sXR7tDojtAIN"
                 }
             },
-            "genres": [
-                "Alternative Country",
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QZHN72553182",
@@ -10567,10 +9965,7 @@
                     "id": "2fs1OUCklhRwQs1MYFJTPw"
                 }
             },
-            "genres": [
-                "Singer/Songwriter",
-                "Folk"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "USRC12500629",
@@ -10601,9 +9996,7 @@
                     "id": "05e0Tkr6tpxbktIei9q8Mw"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBAFL2500306",
@@ -10659,10 +10052,7 @@
                     "url": "https://theberrieswa.bandcamp.com/track/angelus"
                 }
             },
-            "genres": [
-                "Folk-Rock",
-                "Singer/Songwriter"
-            ]
+            "genres": "Folk-Rock"
         },
         {
             "id": "USRC12500398",
@@ -10692,9 +10082,7 @@
                     "id": "5P8zrJH6NhD2QRIscTSTcq"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "UK R&B"
         },
         {
             "id": "QZNWV2548670",
@@ -10725,9 +10113,7 @@
                     "id": "2NvfuuEvIYsfRHJKuzg09y"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "GBHLW2501001",
@@ -10753,10 +10139,7 @@
                     "id": "5Uu9EdaapVI3CrVT6bWe9x"
                 }
             },
-            "genres": [
-                "House",
-                "Dance"
-            ]
+            "genres": "House"
         },
         {
             "id": "UK4UM2500017",
@@ -10782,10 +10165,7 @@
                     "id": "6Zb2xidjoa6IKEcYLMa9qN"
                 }
             },
-            "genres": [
-                "IDM/Experimental",
-                "Electronic"
-            ]
+            "genres": "IDM/Experimental"
         },
         {
             "id": "QZD442001484",
@@ -10816,9 +10196,7 @@
                     "id": "6L3i4jdNnk0a9kMT3qIqTG"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "USSM12501025",
@@ -10844,9 +10222,7 @@
                     "id": "4EJjVfB2pQNn0ZFe1DgUOX"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USBQU2500186",
@@ -10871,9 +10247,7 @@
                     "id": "6EU8H0Nvnob3P99vWMT8vh"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "GBAFL2500302",
@@ -10931,10 +10305,7 @@
                     "id": "1D7qrNAEbZ0G4oR6YZTvFK"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "UKQNW2500001",
@@ -10965,9 +10336,7 @@
                     "id": "3cqAMw4w9px9nAV6iROr0a"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Grime"
         },
         {
             "id": "USUM72505355",
@@ -10993,9 +10362,7 @@
                     "id": "43awRzMhW0Dfcg6MrBBnw0"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUM72412584",
@@ -11026,9 +10393,7 @@
                     "id": "5IoPnNiYAOvHHJpz13wzRL"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBBPW2501489",
@@ -11054,9 +10419,7 @@
                     "id": "4KmNLSvaKU0zoJhIptn961"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "YT:0ZZOukZoQ1g",
@@ -11100,9 +10463,7 @@
                     "id": "0WsC4ETIXyiHDMXRaPMvKe"
                 }
             },
-            "genres": [
-                "Melodic Rap"
-            ]
+            "genres": "Melodic Rap"
         },
         {
             "id": "GBUM72401610",
@@ -11128,9 +10489,7 @@
                     "id": "35ISBknsCeZQtq66xABI9g"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USRC12403827",
@@ -11156,9 +10515,7 @@
                     "id": "2E7a96qey4AzSOdK6H21vS"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B"
         },
         {
             "id": "QZVM32200315",
@@ -11184,9 +10541,7 @@
                     "id": "5QrD3NhHGvHopwK8cbu6mS"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBLZC2500021",
@@ -11212,9 +10567,7 @@
                     "id": "1fZVOJkqVsjbh7TbRCcVlo"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "USUM72502295",
@@ -11240,9 +10593,7 @@
                     "id": "76yJsfb1CUy5Um8nFL7jKQ"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "QMDA62513875",
@@ -11273,9 +10624,7 @@
                     "id": "5hGnVYPjDs12ARhRjAzxCQ"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Latin Folk"
         },
         {
             "id": "UKXN22549554",
@@ -11309,9 +10658,7 @@
                     "url": "https://billywoods.bandcamp.com/track/blk-xmas-featuring-bruiser-wolf"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "YT:7Ko7DH13R0Q",
@@ -11331,9 +10678,7 @@
                     "video_id": "7Ko7DH13R0Q"
                 }
             },
-            "genres": [
-                "Rage Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "USUM72502510",
@@ -11359,9 +10704,7 @@
                     "id": "2ErulGehAyGFfyB9N4HDHP"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBLZC2500001",
@@ -11386,9 +10729,7 @@
                     "id": "6TkqnafmCsB2JavcMkFuwE"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "NZUM72500022",
@@ -11414,9 +10755,7 @@
                     "id": "0vtgMfyOVM2Y97DcVVJw3m"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBBPW2501996",
@@ -11442,10 +10781,7 @@
                     "id": "657y4ybpQX9jyGLRKgNalz"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "UKQC92520001",
@@ -11475,9 +10811,7 @@
                     "id": "3jbL2rMON1hyDCaU4QQTbe"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Score"
         },
         {
             "id": "FR96X2534930",
@@ -11502,10 +10836,7 @@
                     "id": "13jIYWdJqaXqON3URRS6Q3"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USRC12500400",
@@ -11531,9 +10862,7 @@
                     "id": "1leMmYw98725djni7wSYhq"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USAT22504693",
@@ -11559,9 +10888,7 @@
                     "id": "2wn0AYkmcF0Cm7PmvA7hJ7"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USUG12501129",
@@ -11587,9 +10914,7 @@
                     "id": "3AWDeHLc88XogCaCnZQLVI"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USC4R2450081",
@@ -11619,9 +10944,7 @@
                     "id": "5Mt9Jy5q3Z0DaDxRcZMVOQ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QT3FA2592475",
@@ -11647,10 +10970,7 @@
                     "id": "53uhTsdGotEgrDAJydRSov"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "USMRG2586102",
@@ -11679,10 +10999,7 @@
                     "url": "https://friendshipphl.bandcamp.com/track/tree-of-heaven"
                 }
             },
-            "genres": [
-                "Singer/Songwriter",
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "GBBPW2401025",
@@ -11708,9 +11025,7 @@
                     "id": "36MzQtHbBHdefK2que90MO"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "GBCVZ2400267",
@@ -11733,10 +11048,7 @@
                     "id": "2Ht1gsebaD2W5LWAZvYoPG"
                 }
             },
-            "genres": [
-                "Slowcore",
-                "Post-Rock"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "QMFME2534725",
@@ -11761,10 +11073,7 @@
                     "id": "6o9RVwLINAd1COHkmv0TZd"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USA2Z2500619",
@@ -11790,10 +11099,7 @@
                     "id": "2UaTUbuCaQOdWk0q0bDRYl"
                 }
             },
-            "genres": [
-                "Punk",
-                "Alternative"
-            ]
+            "genres": "Egg Punk"
         },
         {
             "id": "NGUM72400100",
@@ -11819,10 +11125,7 @@
                     "id": "6NOrpcicPUh2eaj8bAD44u"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "USUM72503423",
@@ -11848,9 +11151,7 @@
                     "id": "0gTzUSGlZvhrSz72OnBijn"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USSM12503270",
@@ -11876,9 +11177,7 @@
                     "id": "1EUCFwyhBlHxGVKlqe6Dw7"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "FRX282585484",
@@ -11903,9 +11202,7 @@
                     "id": "29YCXYGQo3YU7lx3g2EgLI"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QMFME2559825",
@@ -11931,10 +11228,7 @@
                     "id": "31O8ZZCnYkHonBL00glsTT"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "GBAYE2500161",
@@ -11960,9 +11254,7 @@
                     "id": "1SsyXtMR9nDhGCqJeWPB0r"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBTZZ2500015",
@@ -11988,9 +11280,7 @@
                     "id": "3wE1c11pDVYtMKb0lgqGdN"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Dance"
         },
         {
             "id": "FR96X2561175",
@@ -12019,9 +11309,7 @@
                     "url": "https://finefinefinefine.bandcamp.com/track/i-could"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUYG1741104",
@@ -12050,9 +11338,7 @@
                     "url": "https://rochellejordan.bandcamp.com/track/the-boy"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "UKS362400258",
@@ -12082,9 +11368,7 @@
                     "id": "68Y9Fv5hpOeRRLVItcWAd0"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "QZZEC2466600",
@@ -12110,10 +11394,7 @@
                     "id": "0uq0OrFNaOhCDOlySbYTUx"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Mexican Indie"
         },
         {
             "id": "UKXN22549555",
@@ -12138,9 +11419,7 @@
                     "id": "7oSiIeLokeBcz55p8fT352"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USLD91775388",
@@ -12166,9 +11445,7 @@
                     "id": "5PCn4ysnzhILLhQY0u4Ans"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Chicago Drill"
         },
         {
             "id": "NZUM72500025",
@@ -12194,9 +11471,7 @@
                     "id": "1cQQB9z7fNQQ2VzSkslt7Y"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GX9SP2500005",
@@ -12222,10 +11497,7 @@
                     "id": "1pgOxuh7detTTpsURRAHjX"
                 }
             },
-            "genres": [
-                "Dance",
-                "Techno"
-            ]
+            "genres": "Dub Techno"
         },
         {
             "id": "CAHL42511701",
@@ -12251,9 +11523,7 @@
                     "id": "76cifUIaquJRo1utBIenpZ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "QM84B2510502",
@@ -12279,10 +11549,7 @@
                     "id": "4nvzhSt4cQ727P3zkRV2oc"
                 }
             },
-            "genres": [
-                "Jazz",
-                "Electronic"
-            ]
+            "genres": "Ambient Jazz"
         },
         {
             "id": "CA5KR2511746",
@@ -12308,10 +11575,7 @@
                     "id": "0FAlG6uOeaXWuRdDxaeIQY"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "QMF922550097",
@@ -12337,9 +11601,7 @@
                     "id": "0XUiXuJ817oHMeqM3W3KWi"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Musicals"
         },
         {
             "id": "GBAFL2500304",
@@ -12392,9 +11654,7 @@
                     "id": "53v5RuuAux3F8anCHDNwXI"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "QZ5FN2550041",
@@ -12419,9 +11679,7 @@
                     "id": "2hnLGF7CvK1ACEXVNRNkDi"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Footwork"
         },
         {
             "id": "USAT22504684",
@@ -12447,9 +11705,7 @@
                     "id": "7dHblXsJTRemgyIvFNJE7t"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QMEU32501402",
@@ -12482,9 +11738,7 @@
                     "url": "https://chatpile.bandcamp.com/track/radioactive-dreams"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "QM6YT2607406",
@@ -12510,10 +11764,7 @@
                     "id": "5h9FYRmddlb1x0ybleGPxY"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "GBAFL2500300",
@@ -12565,10 +11816,7 @@
                     "id": "5dAM0dvquAo2Oha9i1J8jb"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "USUM72501877",
@@ -12594,9 +11842,7 @@
                     "id": "1LsisG6aoqfsF1r6M4LpMO"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "USAT22410193",
@@ -12622,9 +11868,7 @@
                     "id": "3lBRPvbrZQKI8EOXBNYdNO"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSM12502019",
@@ -12650,9 +11894,7 @@
                     "id": "7sGQ4jAOUs3YG1CFyjDxdc"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "DEAL32300482",
@@ -12678,10 +11920,7 @@
                     "id": "24kIbzb70Cc8GX09mC6k4U"
                 }
             },
-            "genres": [
-                "House",
-                "Dance"
-            ]
+            "genres": "Queercore"
         },
         {
             "id": "DEG932501019",
@@ -12707,10 +11946,7 @@
                     "id": "3ezTBOGeNUNpx4h8ToEl4O"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Electronic"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USC4R2559054",
@@ -12736,9 +11972,7 @@
                     "id": "5Oq6iKIWE3Q1i3G2fES5Oc"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USRO22505026",
@@ -12763,10 +11997,7 @@
                     "id": "7oUiQH66dtqxiUuRgrRrz6"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative Folk"
         },
         {
             "id": "QM7282591514",
@@ -12797,9 +12028,7 @@
                     "id": "1xqT27jSG1Y15vOXfsV0gv"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USUG12500247",
@@ -12825,9 +12054,7 @@
                     "id": "1TYLYTMtSIqqPpOGJhmp0y"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "US2S72513056",
@@ -12858,10 +12085,7 @@
                     "id": "1MRQ49rkgqahm7K51ZjtRf"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "GBRKQ2548624",
@@ -12887,9 +12111,7 @@
                     "id": "5WtSUNzsF6LM46V1S1D32s"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "USA2P2512792",
@@ -12914,9 +12136,7 @@
                     "id": "6CZKeP30SneJmRQpYxLCYZ"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "OTHER:https://decius.bandcamp.com/track/nutrition-position-type-i",
@@ -12935,9 +12155,7 @@
                     "url": "https://decius.bandcamp.com/track/nutrition-position-type-i"
                 }
             },
-            "genres": [
-                "Acid House"
-            ]
+            "genres": "Acid House"
         },
         {
             "id": "USOPM2400429",
@@ -12963,10 +12181,7 @@
                     "id": "2aQIBBFWfv5zlCjovi1u5a"
                 }
             },
-            "genres": [
-                "Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QM6N22553528",
@@ -12992,9 +12207,7 @@
                     "id": "1AZwVoUx3UF5JbkUeMSUGe"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USYFZ2560801",
@@ -13020,10 +12233,7 @@
                     "id": "0PsFsv5xUyX06ZhIEtFkeA"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Metal"
         },
         {
             "id": "GBUM72506028",
@@ -13049,9 +12259,7 @@
                     "id": "3qpbRVi19oJw1jMRSaNFPN"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Grime"
         },
         {
             "id": "USLD91775286",
@@ -13077,9 +12285,7 @@
                     "id": "7E57zDS9CWw46fOwKDGEm0"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USSM12501026",
@@ -13105,9 +12311,7 @@
                     "id": "0D7ptTqe5bFfHPn2PWJWoC"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "SE5AJ2202464",
@@ -13132,9 +12336,7 @@
                     "id": "2Kal87D1p0qVj7ZKsUsl2T"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "ES5022500376",
@@ -13160,10 +12362,7 @@
                     "id": "22hH0aVWmxNW3clG1Dck8F"
                 }
             },
-            "genres": [
-                "Pop Latino",
-                "Latin"
-            ]
+            "genres": "Pop Latino"
         },
         {
             "id": "NZUM72500030",
@@ -13194,9 +12393,7 @@
                     "id": "6ghDayhHeBXAP4OOnnrFW9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USAT22506963",
@@ -13222,9 +12419,7 @@
                     "id": "1BeyjPUWYbHcthHjusrejv"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBAJC2500135",
@@ -13250,9 +12445,7 @@
                     "id": "1MkSNJ5s4yvdOoeB9DQqGP"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "FR2X42580139",
@@ -13278,10 +12471,7 @@
                     "id": "0fOF5w2AEpkAnWL4AkBiO5"
                 }
             },
-            "genres": [
-                "Techno",
-                "Dance"
-            ]
+            "genres": "Techno"
         },
         {
             "id": "USUYG1719619",
@@ -13312,9 +12502,7 @@
                     "id": "6sJR82bgpwFPjzB1DHzGw8"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "QMRSZ2402034",
@@ -13340,9 +12528,7 @@
                     "id": "21Oh412OvkEtnqkYhrtLE2"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "USZ4V2500251",
@@ -13367,10 +12553,7 @@
                     "id": "7cl1kr7pqaXdDov0lf6cQq"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "GBARL2500466",
@@ -13396,9 +12579,7 @@
                     "id": "394f1gySTJHUskHFpTxTW9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "US38Y2445007",
@@ -13428,9 +12609,7 @@
                     "id": "06o2hgwnRJN0HYelhyVsLm"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZVR22500335",
@@ -13456,9 +12635,7 @@
                     "id": "5gqNyUJ8eJGzDByrB4cS7s"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USRC12501059",
@@ -13484,10 +12661,7 @@
                     "id": "2t3v2HTN5Rc8QMWJOPO847"
                 }
             },
-            "genres": [
-                "Country",
-                "Singer/Songwriter"
-            ]
+            "genres": "Country"
         },
         {
             "id": "FR59R2589034",
@@ -13516,9 +12690,7 @@
                     "url": "https://smerzforyou.bandcamp.com/track/feisty"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USTJ22563202",
@@ -13543,10 +12715,7 @@
                     "id": "4ZaJZcd7lSFswJ8qBiF5yZ"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "USQE92500211",
@@ -13572,9 +12741,7 @@
                     "id": "47N21fn8V8IN392MGlicT5"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USAT22504696",
@@ -13600,9 +12767,7 @@
                     "id": "2cBtsB7Pi89q9yWk59a2sX"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USLD91772034",
@@ -13628,9 +12793,7 @@
                     "id": "2kZoOj1n5vk9BuF0sih58M"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Dark R&B"
         },
         {
             "id": "QZNWP2551563",
@@ -13658,9 +12821,7 @@
                     "url": "https://ninaaaaaaaaaaa13.bandcamp.com/track/idol-time"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "SE2WJ2507010",
@@ -13686,10 +12847,7 @@
                     "id": "2Bn55HuKt3EhQ4AdBGKNAn"
                 }
             },
-            "genres": [
-                "House",
-                "Dance"
-            ]
+            "genres": "House"
         },
         {
             "id": "GBEXH2401987",
@@ -13715,10 +12873,7 @@
                     "id": "0fSkyMme1Ze8ewpcbsiuIs"
                 }
             },
-            "genres": [
-                "Electronica",
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "GBARL2500563",
@@ -13749,10 +12904,7 @@
                     "id": "4DREBgUie15tAPq9KQqe2c"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "GBCFB2401384",
@@ -13783,9 +12935,7 @@
                     "id": "4U9ZjqhaGF9wl56899E4sW"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "NGUM72500065",
@@ -13811,10 +12961,7 @@
                     "id": "3qS4spuVywoeh9uGIpRuQh"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "GBAHT2500513",
@@ -13840,9 +12987,7 @@
                     "id": "7vBOMoBKb6InbMdQiFwRCO"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM7282558735",
@@ -13868,9 +13013,7 @@
                     "id": "7aamc4vRYmHLYI2aKTDjdJ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "USQX92504806",
@@ -13896,10 +13039,7 @@
                     "id": "3C9H7htrTDVHrP8BiB2f2r"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "QZNWS2523852",
@@ -13925,10 +13065,7 @@
                     "id": "50ASFow3YrVJJpqdzaM1YD"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "QZWFG2585451",
@@ -13954,10 +13091,7 @@
                     "id": "42T8sQmsrdEuEFqDAHrhSz"
                 }
             },
-            "genres": [
-                "Dance",
-                "Electronic"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "QMFMF2450875",
@@ -13983,10 +13117,7 @@
                     "id": "7K9DMSR7ZlN1aAzJas8220"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "QMV8L2335304",
@@ -14012,10 +13143,7 @@
                     "id": "2g5S7Pf6SIHzdw47muIDw9"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USAT22411431",
@@ -14041,9 +13169,7 @@
                     "id": "2nrY3Snk7Tqf2QOwzLAWQf"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Post-Grunge"
         },
         {
             "id": "USUG12501758",
@@ -14069,9 +13195,7 @@
                     "id": "42GKyvz5KBsHTBaLpo3cqJ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZHN72552650",
@@ -14102,10 +13226,7 @@
                     "id": "7DX8AHCJlg91W9lH9JT5vv"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "R&B/Soul"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USAT22505902",
@@ -14131,9 +13252,7 @@
                     "id": "3W3Y2kXSOkDidmXerJLLU2"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "USQX92501238",
@@ -14159,10 +13278,7 @@
                     "id": "4Xpt2bVLKFvlL5agz7cBTj"
                 }
             },
-            "genres": [
-                "Pop Latino",
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "DEU162507158",
@@ -14188,9 +13304,7 @@
                     "id": "2bMTr1ekSRhzQqsv1raIlC"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Jangle Pop"
         },
         {
             "id": "USUG12502629",
@@ -14216,9 +13330,7 @@
                     "id": "2KrQbq3aqGOFGnkTKnN2XA"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "USWB12503079",
@@ -14244,10 +13356,7 @@
                     "id": "3H3kzlDWxN9KEFuUtv39p2"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Alternative"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "GBBPW2501734",
@@ -14273,9 +13382,7 @@
                     "id": "29uMN6cjcQZeozasX35vxq"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USJZA2651409",
@@ -14301,9 +13408,7 @@
                     "id": "35nEske60pQJNgUrEgf9xW"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Free Jazz"
         },
         {
             "id": "QZTLA2506400",
@@ -14329,10 +13434,7 @@
                     "id": "6JWlIiYcEgYGNF8oNaMpZP"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "UK Garage"
         },
         {
             "id": "USA2P2505011",
@@ -14358,9 +13460,7 @@
                     "id": "65hG7wpGsBD591lcfzEmHC"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUM72407575",
@@ -14386,9 +13486,7 @@
                     "id": "4uUih1tl2qNtucRds8RZgu"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "QZS7J2561017",
@@ -14414,9 +13512,7 @@
                     "id": "1WnvTJMxPIoXT7PV9mdNHk"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Sexy Drill"
         },
         {
             "id": "USWB12500485",
@@ -14442,9 +13538,7 @@
                     "id": "5Ky8wE5v2dNXn5XWlBM28k"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBBKS2500005",
@@ -14467,9 +13561,7 @@
                     "id": "2SWIGZAAIpDVXk13FrJBzM"
                 }
             },
-            "genres": [
-                "Idm"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "GBGEY2400072",
@@ -14494,9 +13586,7 @@
                     "id": "0js5CrHTU81zorsAUfi3un"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USUG12506962",
@@ -14522,9 +13612,7 @@
                     "id": "3y3RHjj31HtHZEw9zkEoQI"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "USSM12408428",
@@ -14550,10 +13638,7 @@
                     "id": "4pftaoQbbheCXSdleWIeDK"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Rap"
-            ]
+            "genres": "UK Drill"
         },
         {
             "id": "US2S72513014",
@@ -14579,10 +13664,7 @@
                     "id": "6eebVrIT3HMKnyJq8PqDG4"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "YT:En1aA0Xi4p8",
@@ -14605,9 +13687,7 @@
                     "url": "https://hotlinetnt.bandcamp.com/track/candle"
                 }
             },
-            "genres": [
-                "Shoegaze"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "QZWFF2526457",
@@ -14633,9 +13713,7 @@
                     "id": "0GhVtqzmazON0vBT3ktTWQ"
                 }
             },
-            "genres": [
-                "Worldwide"
-            ]
+            "genres": "Shatta"
         },
         {
             "id": "UGA262300276",
@@ -14660,9 +13738,7 @@
                     "id": "1WkDLBRal0YO4YUyF8lL32"
                 }
             },
-            "genres": [
-                "Brazilian"
-            ]
+            "genres": "Funk Bruxaria"
         },
         {
             "id": "USSM12407085",
@@ -14688,10 +13764,7 @@
                     "id": "1Cbl3Yq8rHo7hhDQmLQagU"
                 }
             },
-            "genres": [
-                "Pop",
-                "R&B/Soul"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "QZES72502063",
@@ -14717,9 +13790,7 @@
                     "id": "34ZNVmPISt18mxi0V5uHyk"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "USBQU2500078",
@@ -14745,9 +13816,7 @@
                     "id": "0xATIfA17cJDb9pYAuw70Y"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "QMHBS2400212",
@@ -14773,9 +13842,7 @@
                     "id": "56fy1fC0cxRpoEDMySEGBv"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USA2P2503458",
@@ -14801,9 +13868,7 @@
                     "id": "5Z75FvRFiultmPFWHx5jQ7"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Corrido"
         },
         {
             "id": "HKE672500362",
@@ -14829,10 +13894,7 @@
                     "id": "7Fc7XdmrmTUQBoeU8MXIbN"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Chinese Hip-Hop"
-            ]
+            "genres": "Chinese Hip Hop"
         },
         {
             "id": "USUG12501754",
@@ -14858,9 +13920,7 @@
                     "id": "4WNaefp3sGsnTBzHEQb97g"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBBPW2502109",
@@ -14886,10 +13946,7 @@
                     "id": "4hSTvY4GQrNDC2TsCwhEFc"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Alternative"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USAT22404702",
@@ -14915,9 +13972,7 @@
                     "id": "13QINbzgh3yta5OGvB77Pl"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USA2P2551924",
@@ -14943,9 +13998,7 @@
                     "id": "5NbilllIdF8lp4FmdX7OF8"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "USQX92504223",
@@ -14976,10 +14029,7 @@
                     "id": "1NXbNEAcPvY5G1xvfN57aA"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Neo-Psychedelic"
         },
         {
             "id": "US3DF2580402",
@@ -15005,10 +14055,7 @@
                     "id": "3zsOkhislzbxzFOSQuPIr9"
                 }
             },
-            "genres": [
-                "Country",
-                "Pop"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USAT22504686",
@@ -15034,9 +14081,7 @@
                     "id": "37tH9V9YK8P9Q2oGfZjJXy"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USAT22503401",
@@ -15059,10 +14104,7 @@
                     "id": "5xalbHoIf0F0AmuTKlm2Ct"
                 }
             },
-            "genres": [
-                "House",
-                "Tech House"
-            ]
+            "genres": "House"
         },
         {
             "id": "USEP42520005",
@@ -15093,9 +14135,7 @@
                     "id": "5RCUuWLW5FcfSisq2V4BMa"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "OTHER:https://youonlydie1nce.com/products/you-only-die-once-cd-album",
@@ -15114,10 +14154,7 @@
                     "url": "https://youonlydie1nce.com/products/you-only-die-once-cd-album"
                 }
             },
-            "genres": [
-                "Jazz Rap",
-                "Alternative Hip Hop"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "GBCEL2400271",
@@ -15142,9 +14179,7 @@
                     "id": "4zND6NKoMq9ZkjvDAHAgqH"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "CA21O2512204",
@@ -15170,10 +14205,7 @@
                     "id": "6cbLpZ56tlJYHueIgfCLzd"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USRC12500744",
@@ -15199,10 +14231,7 @@
                     "id": "3wyntMwz2XfUWy3O7ukBbD"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "QMDA62491858",
@@ -15228,10 +14257,7 @@
                     "id": "1A9NdpGfoDP1369R1xZ4mZ"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "QZAKB2532496",
@@ -15257,10 +14283,7 @@
                     "id": "0dqAyHWEXNCH83W7uctKTn"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12503054",
@@ -15291,9 +14314,7 @@
                     "id": "6SA3oIwGyURRVZkbvC5lQD"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie"
         },
         {
             "id": "QMRSZ2501716",
@@ -15319,9 +14340,7 @@
                     "id": "36J9vpPpatRDkMkee0PFCe"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Industrial Rock"
         },
         {
             "id": "QMBZ92541837",
@@ -15347,9 +14366,7 @@
                     "id": "2egIlhalVEVQhvt9W11u82"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "Afroswing"
         },
         {
             "id": "USRC12501795",
@@ -15375,9 +14392,7 @@
                     "id": "2qGvxAKXbajPFRb9ybIMOD"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USAT22501697",
@@ -15403,10 +14418,7 @@
                     "id": "2fhVsI54lSCFyW7sw5WPfR"
                 }
             },
-            "genres": [
-                "Afro-Pop",
-                "African"
-            ]
+            "genres": "Kompa"
         },
         {
             "id": "USSE62400098",
@@ -15432,9 +14444,7 @@
                     "id": "74hD8ZuQLIZyCr597HHAqJ"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Celtic Rock"
         },
         {
             "id": "QMDA72558182",
@@ -15460,9 +14470,7 @@
                     "id": "5hKjvZFDOkBcJgeT7bF61A"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Old School Hip Hop"
         },
         {
             "id": "USUG12509789",
@@ -15488,9 +14496,7 @@
                     "id": "5f9JpyT70rksel4mcQg0a7"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZD442001486",
@@ -15516,9 +14522,7 @@
                     "id": "0mwlZQjUxspUTpAzLwexw7"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "USUYG1700201",
@@ -15544,9 +14548,7 @@
                     "id": "499OiYFGkuTO74jb9tKv8Z"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBUM72403268",
@@ -15572,9 +14574,7 @@
                     "id": "6gBjUipB0ZxHd1BvwdJTDQ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "UKXN22549561",
@@ -15600,9 +14600,7 @@
                     "id": "5yCnuMeWqqpw6cvXeMD8MH"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USMTD2400674",
@@ -15649,10 +14647,7 @@
                     "id": "4mdgvCTOLBexTX8UrmYyw8"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Singer/Songwriter"
-            ]
+            "genres": "Japanese Indie"
         },
         {
             "id": "QZXPU2500003",
@@ -15678,9 +14673,7 @@
                     "id": "0GQkx88Fpkm7qlbrdggdNO"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "GBARL2500442",
@@ -15706,9 +14699,7 @@
                     "id": "5FxdLsAmaOo8ofpNvsSun5"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie"
         },
         {
             "id": "USUG12501602",
@@ -15734,9 +14725,7 @@
                     "id": "5z0LSDpPpGwc2ZyJHpsE3J"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USAT22500013",
@@ -15762,10 +14751,7 @@
                     "id": "2gFHcEzp9aooYWJgWdkglG"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Black Metal"
         },
         {
             "id": "DEG932406913",
@@ -15790,9 +14776,7 @@
                     "id": "0HjYuuMp6oljg3n9me62zP"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Experimental"
         },
         {
             "id": "QZMHL2586747",
@@ -15818,9 +14802,7 @@
                     "id": "26S2Z8upUulL1YCMSD4ug2"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "USUYG1741108",
@@ -15846,9 +14828,7 @@
                     "id": "6pcXJ39XevPFNqXuUDClsf"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "YT:zechDq_VNk4",
@@ -15896,9 +14876,7 @@
                     "id": "0P5PPuVLKdyHnWdjbOeMxa"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBCEL2500227",
@@ -15927,9 +14905,7 @@
                     "url": "https://sorrybanduk.bandcamp.com/track/echoes"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBUNP2500301",
@@ -15954,10 +14930,7 @@
                     "id": "05XVJA1uDIULsh4TzWBPap"
                 }
             },
-            "genres": [
-                "Techno",
-                "Dance"
-            ]
+            "genres": "Techno"
         },
         {
             "id": "USUG12503277",
@@ -15983,10 +14956,7 @@
                     "id": "1k51Q6GFWBbsaWlBB2gnzo"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "GBPVV2406333",
@@ -16012,9 +14982,7 @@
                     "id": "6Ar4d3N45kgvYuRYj7yKX6"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USRC12501226",
@@ -16040,9 +15008,7 @@
                     "id": "0XnxrosRIxY1nKFJ7wc5Ut"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "UK R&B"
         },
         {
             "id": "QZTLA2576939",
@@ -16068,9 +15034,7 @@
                     "id": "0z0fnR1VkGhdihpoXOUx6T"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Sexy Drill"
         },
         {
             "id": "QMFMF2594027",
@@ -16096,10 +15060,7 @@
                     "id": "02WYUqxhFKrmsfXeguqlvW"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "USZ4V2500035",
@@ -16128,10 +15089,7 @@
                     "url": "https://bassvictim.bandcamp.com/track/forever-salty"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "DEH742528037",
@@ -16156,9 +15114,7 @@
                     "id": "3BvmHUWrVYDTp7khu6Y5Qm"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "QM24S2504723",
@@ -16184,9 +15140,7 @@
                     "id": "6vTpNnr2dryDKW5wNpAJJH"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USQX92501931",
@@ -16212,10 +15166,7 @@
                     "id": "3ftYF085hfCdYGB0nus3fW"
                 }
             },
-            "genres": [
-                "Soundtrack",
-                "Blues"
-            ]
+            "genres": "Score"
         },
         {
             "id": "USRC12403577",
@@ -16241,9 +15192,7 @@
                     "id": "541sN2qNfIlllGn9nGOQoC"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUG12502492",
@@ -16269,9 +15218,7 @@
                     "id": "5QD9PUqyVz8syPaZL4HAbB"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "GBAFL2400552",
@@ -16294,9 +15241,7 @@
                     "id": "1EkxfGivWsIwCJTdz359xl"
                 }
             },
-            "genres": [
-                "Art Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USFP72484104",
@@ -16322,9 +15267,7 @@
                     "id": "4I939vqD5prXBpMlyDjbuw"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Dream Pop"
         },
         {
             "id": "USZ4V2500303",
@@ -16350,10 +15293,7 @@
                     "id": "1Dcfp94Bmjnih9IYD6qV6K"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "USQX92501827",
@@ -16379,9 +15319,7 @@
                     "id": "04ncMwTyse8X37iIUT4na1"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt\u00e9"
         },
         {
             "id": "USSUB2571301",
@@ -16406,9 +15344,7 @@
                     "id": "3sLQeqH2lSweq47Lr9IPA9"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Drone Metal"
         },
         {
             "id": "USMTD2400791",
@@ -16431,10 +15367,7 @@
                     "id": "6BHZGzza22cxWzNj4zbrh3"
                 }
             },
-            "genres": [
-                "Noise Rock",
-                "Post-Punk"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "SE5AJ2202609",
@@ -16463,10 +15396,7 @@
                     "url": "https://music.apple.com/us/album/struggle-with-the-beast/1830987314?i=1830987564"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Neofolk"
         },
         {
             "id": "US5TA2500203",
@@ -16492,10 +15422,7 @@
                     "id": "4pH8rClaLsi6QcDGrw2VgV"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "USAT22504015",
@@ -16521,9 +15448,7 @@
                     "id": "5l8ylBEHHYL62w5HfjB3JF"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "DED622500014",
@@ -16549,10 +15474,7 @@
                     "id": "3wCJGNuWIoeKHsrZdAybiO"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Riot Grrrl"
         },
         {
             "id": "USUM72511356",
@@ -16578,9 +15500,7 @@
                     "id": "0tBXqaYjAqaQp55uRdhgAt"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "SE5AJ2202392",
@@ -16606,10 +15526,7 @@
                     "id": "5gR6gTGOGsg9zcR7JhvwQz"
                 }
             },
-            "genres": [
-                "Punk",
-                "Alternative"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "USUM72500023",
@@ -16635,9 +15552,7 @@
                     "id": "0bDEU7hnvPcf3OflOCPUzx"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Jersey Club"
         },
         {
             "id": "QZNWZ2587788",
@@ -16662,10 +15577,7 @@
                     "id": "2Zrve0SeR4E9ao9EO2z8au"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "US58L2594402",
@@ -16691,10 +15603,7 @@
                     "id": "5Zkp38EROuQ9Elsep22Ov4"
                 }
             },
-            "genres": [
-                "Singer/Songwriter",
-                "Jazz"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "USRC12500753",
@@ -16720,10 +15629,7 @@
                     "id": "7AAcT7MunkAjHyk9Abg774"
                 }
             },
-            "genres": [
-                "Pop",
-                "Singer/Songwriter"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZK6L2584602",
@@ -16749,9 +15655,7 @@
                     "id": "59029WsRfhwA8Vqez1QSeY"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "USJ5G2442502",
@@ -16776,9 +15680,7 @@
                     "id": "7yDcE8l5OFDRSrsHhqgP4c"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZS7J2591999",
@@ -16804,10 +15706,7 @@
                     "id": "37Pvim4Q5XnvMFxaUgBwUl"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Alternative"
-            ]
+            "genres": "Jungle"
         },
         {
             "id": "QT3F52501725",
@@ -16833,10 +15732,7 @@
                     "id": "37lYjMF2wbLow8pOJBtIMx"
                 }
             },
-            "genres": [
-                "Pop",
-                "Alternative"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMKRW2500113",
@@ -16862,9 +15758,7 @@
                     "id": "3qkwosSpGEJZYlGApYl4uj"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USCGJ2539907",
@@ -16889,10 +15783,7 @@
                     "id": "71MvaHIcqkUfwiKebC0wBw"
                 }
             },
-            "genres": [
-                "Rock",
-                "Metal"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "GB5KW2500224",
@@ -16918,9 +15809,7 @@
                     "id": "7EzM6R4sRxT2tcHod3Yf5N"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "NOSTS2525020",
@@ -16946,9 +15835,7 @@
                     "id": "0gRPbCjHQ3B5R7LnYdxdJg"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Dub Techno"
         },
         {
             "id": "USUG12505895",
@@ -16974,9 +15861,7 @@
                     "id": "3Ws7pcKeEo6dW2xPUFgmQv"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USUG12502404",
@@ -17002,9 +15887,7 @@
                     "id": "6sMsaVXPKzhf01WvaRFAEI"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QT4K52579714",
@@ -17033,9 +15916,7 @@
                     "url": "https://zayallcaps.bandcamp.com/track/work-it-out-ft-disco-sam"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "NL8RL2514209",
@@ -17061,9 +15942,7 @@
                     "id": "735Ji1GzLR9nvteGdbqy8U"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USUG12504525",
@@ -17089,9 +15968,7 @@
                     "id": "0nafF9MxcXJBQWv3BTKtdF"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "QMDA72543804",
@@ -17117,9 +15994,7 @@
                     "id": "50BLjPGDh9DjVp4qwwyG6d"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6MZ2556407",
@@ -17145,9 +16020,7 @@
                     "id": "2L795xcNWrKrqdhzmEUVCq"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QZ8SH2506505",
@@ -17178,10 +16051,7 @@
                     "id": "5nOQxqzBM7DjLpkRMEJNIB"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "NOSTS2525070",
@@ -17210,9 +16080,7 @@
                     "url": "https://sambarker.bandcamp.com/track/fluid-mechanics"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Dub Techno"
         },
         {
             "id": "ZZA0P2517704",
@@ -17237,10 +16105,7 @@
                     "id": "7t4Z19BqZ23ExgdiOP0nf6"
                 }
             },
-            "genres": [
-                "Dance",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "GBUM72506119",
@@ -17266,9 +16131,7 @@
                     "id": "4lU0whPQnQn0EMgmF46iz0"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "UKQY82500001",
@@ -17294,10 +16157,7 @@
                     "id": "3292GQO43rGyNlKmZvY0Es"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "USA2P2540980",
@@ -17323,9 +16183,7 @@
                     "id": "0o1TOuRqbAP2RspbKZmq7P"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "USRC12500013",
@@ -17351,10 +16209,7 @@
                     "id": "4Lojbtk7XNMdSKRHSFbdkm"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Progressive Metal"
         },
         {
             "id": "QZZ772443523",
@@ -17380,10 +16235,7 @@
                     "id": "3kAbFnoFDqPIEkt5Nj5dmS"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USBQU2500047",
@@ -17409,9 +16261,7 @@
                     "id": "05RT6GsIKwEewOcYFGhm9x"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GB3742500014",
@@ -17437,9 +16287,7 @@
                     "id": "3NxwCv3ZF7kYcqtLoplsgf"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Progressive Rock"
         },
         {
             "id": "GBCKK2578607",
@@ -17465,9 +16313,7 @@
                     "id": "3Voqx8yWpN1VcK38Ueptjf"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Folk"
         },
         {
             "id": "QZWV32518605",
@@ -17493,9 +16339,7 @@
                     "id": "4hHsUOXOCyxXyZn2pDEzXX"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Spoken Word"
         },
         {
             "id": "GBCKB2513401",
@@ -17521,10 +16365,7 @@
                     "id": "3kAgqfc8ENlt0wC5q7EEG7"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "DEU672500779",
@@ -17550,10 +16391,7 @@
                     "id": "30zm82YogyGUn4S9dE8vcq"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Electronica"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "GBARL2500443",
@@ -17579,9 +16417,7 @@
                     "id": "1gqxVK8URuPT86iFbv2vVL"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie"
         },
         {
             "id": "SE5JH2401001",
@@ -17607,9 +16443,7 @@
                     "id": "0b6u5RhZd8H8rVHROCKgsF"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Spoken Word"
         },
         {
             "id": "USRC12500859",
@@ -17635,9 +16469,7 @@
                     "id": "0OhW6F1LavQzbjZSc8YrZG"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "GBCVZ2500163",
@@ -17660,9 +16492,7 @@
                     "id": "5Jsks3IWyaeFVEjmVtw2H3"
                 }
             },
-            "genres": [
-                "Retro Pop"
-            ]
+            "genres": "Retro Pop"
         },
         {
             "id": "USEP42539002",
@@ -17688,9 +16518,7 @@
                     "id": "2HkwY8ossKTSESTUTMY4gD"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Egg Punk"
         },
         {
             "id": "GBPVV2404392",
@@ -17716,9 +16544,7 @@
                     "id": "7wtp2m3k1tc6Phm2EsGbDf"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Horror Punk"
         },
         {
             "id": "GBKZV2500019",
@@ -17744,9 +16570,7 @@
                     "id": "73nIZ3ufCricmbo1oPZfjt"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QZG4T2400017",
@@ -17772,9 +16596,7 @@
                     "id": "15EOCEksKtUd844TrW9Tjv"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUM72503325",
@@ -17800,9 +16622,7 @@
                     "id": "08GgZyqoP4icrkBMJFu9PN"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QMBZ92577791",
@@ -17828,10 +16648,7 @@
                     "id": "0J5ZUWqmG8QPo46Cbwr53a"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "East Coast Hip Hop"
         },
         {
             "id": "GBBKS2500089",
@@ -17854,10 +16671,7 @@
                     "id": "78ZmrRcMYPYg3Vdbiq9wG1"
                 }
             },
-            "genres": [
-                "Techno",
-                "Idm"
-            ]
+            "genres": "Techno"
         },
         {
             "id": "QMFME2468372",
@@ -17883,9 +16697,7 @@
                     "id": "5pieyrAHXvmzv3QeXb96I2"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Neo-Psychedelic"
         },
         {
             "id": "USA2P2514526",
@@ -17910,10 +16722,7 @@
                     "id": "5OZfeZTa0R88oA4HCZApom"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "GBJXP2557002",
@@ -17939,10 +16748,7 @@
                     "id": "3hJg9CMDIGZZnz36BJ9Rh9"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Neo-Psychedelic"
         },
         {
             "id": "OTHER:https://massanera.bandcamp.com/track/the-best-is-over",
@@ -17961,9 +16767,7 @@
                     "url": "https://massanera.bandcamp.com/track/the-best-is-over"
                 }
             },
-            "genres": [
-                "Screamo"
-            ]
+            "genres": "Screamo"
         },
         {
             "id": "GB5EM2402175",
@@ -17989,10 +16793,7 @@
                     "id": "1mgId6GPSfCUUVQW41y5JF"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Pop"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
             "id": "US58L2595005",
@@ -18018,10 +16819,7 @@
                     "id": "3Dum7WctMuZgE9xnx7Jgqs"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USOPM2400427",
@@ -18047,10 +16845,7 @@
                     "id": "4UKLF1foe7NVs70zSfkkYg"
                 }
             },
-            "genres": [
-                "Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QMB622504510",
@@ -18076,10 +16871,7 @@
                     "id": "2of9MjqsETuyppM9YphGTl"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZK6G2538681",
@@ -18105,10 +16897,7 @@
                     "id": "6Qw3pU5q0ItsgoZMrsht8X"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Jazz"
-            ]
+            "genres": "UK Grime"
         },
         {
             "id": "QT3AN2500008",
@@ -18134,9 +16923,7 @@
                     "id": "6U3Kmg0GVjza9ZA3yP1R1C"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Modern Blues"
         },
         {
             "id": "GBAJC2500333",
@@ -18162,10 +16949,7 @@
                     "id": "64J1EYisViSUN0LydKHenz"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Punk"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "FRX872537882",
@@ -18191,9 +16975,7 @@
                     "id": "3eYB75f0hJQqzuQ6uOuzaA"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GX2QY2400017",
@@ -18219,9 +17001,7 @@
                     "id": "5munQvyxlq8hZNvTIrKoQT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USY6C2543101",
@@ -18250,10 +17030,7 @@
                     "url": "https://youngwidows.bandcamp.com/track/the-darkest-side"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "GBPVV2406292",
@@ -18279,9 +17056,7 @@
                     "id": "041DJ4hUI6drOqYgLf3QQG"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USFP13788503",
@@ -18307,9 +17082,7 @@
                     "id": "0PBX8l4P0FPtNLloE8AjDl"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "QZWV32576462",
@@ -18335,9 +17108,7 @@
                     "id": "1Ewrkpq1CIwGZ5n4nHqNSe"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "UGA262300238",
@@ -18363,10 +17134,7 @@
                     "id": "2y3Ml5Fd5yH6dST2GSDeCr"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Dance"
-            ]
+            "genres": "Singeli"
         },
         {
             "id": "QZNWR2518754",
@@ -18395,10 +17163,7 @@
                     "url": "https://mspainthattiesburg.bandcamp.com/track/angel"
                 }
             },
-            "genres": [
-                "Punk",
-                "Alternative"
-            ]
+            "genres": "Egg Punk"
         },
         {
             "id": "DED620072928",
@@ -18424,9 +17189,7 @@
                     "id": "01PqV02iL1GK8noTdDRKDX"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "USSM12509552",
@@ -18452,9 +17215,7 @@
                     "id": "0OY2nTgPGvyOS3MR1hJES3"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USA2B2405486",
@@ -18480,10 +17241,7 @@
                     "id": "63XuKXNisjyZrOXkxqgGIi"
                 }
             },
-            "genres": [
-                "Country",
-                "Americana"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "USQX92407609",
@@ -18509,10 +17267,7 @@
                     "id": "0mAGQ3NUF8X4hP55jGAUxu"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "USRC12502354",
@@ -18538,9 +17293,7 @@
                     "id": "0y9S3dw1MBzHqmTpMTTd0M"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUG12500409",
@@ -18566,9 +17319,7 @@
                     "id": "3QfxeNMKiOMFxHVLlR1L1c"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QZVM32200348",
@@ -18594,9 +17345,7 @@
                     "id": "4zhTF6LpMWHPuXWY8mNrY7"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USUG12506182",
@@ -18622,9 +17371,7 @@
                     "id": "4uyBm26e7ElRigCH6vRbpc"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBCFB2500227",
@@ -18650,9 +17397,7 @@
                     "id": "5A6SU4vLMAJZbkTy7C7xXJ"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Lo-Fi House"
         },
         {
             "id": "USJ5G2536503",
@@ -18678,9 +17423,7 @@
                     "id": "10eTDWUAyApKsMkHBwZ3Mb"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSD12500585",
@@ -18706,10 +17449,7 @@
                     "id": "3yBx8j3hVNawnmlrBf3EHR"
                 }
             },
-            "genres": [
-                "Pop Latino",
-                "Latin"
-            ]
+            "genres": "Reggaeton"
         },
         {
             "id": "QM6N22553535",
@@ -18735,9 +17475,7 @@
                     "id": "5PFjKfGf75I3LkKGiReWp5"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USWB12503615",
@@ -18763,9 +17501,7 @@
                     "id": "6N2lPLZFtDOck18VqPpgT2"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBAHS2501280",
@@ -18791,9 +17527,7 @@
                     "id": "7hoPbfGuOZe6FKBlwB2d21"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USSM12501568",
@@ -18819,9 +17553,7 @@
                     "id": "0yKuz6SU0TN3ViDaydV9ti"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUM72501918",
@@ -18847,9 +17579,7 @@
                     "id": "2MIpkAQVJqQIDf9k4YWoHR"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GB5KW2501367",
@@ -18875,9 +17605,7 @@
                     "id": "0kJAopMxyyqtF1GiIIsgzn"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "US38Y2422296",
@@ -18903,10 +17631,7 @@
                     "id": "7bgYrlMU0S1wfNPPD4A91Z"
                 }
             },
-            "genres": [
-                "Pop",
-                "Alternative"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USSM12501027",
@@ -18932,9 +17657,7 @@
                     "id": "22WFoPT9VIJlZ0VcJVkCpm"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USJ5G2536509",
@@ -18960,9 +17683,7 @@
                     "id": "2RMtMVvGaQMW4sVfnb4bHy"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USEP42529004",
@@ -18988,10 +17709,7 @@
                     "id": "6UFDma78AVAyHaN4i88R8i"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Alternative"
-            ]
+            "genres": "Soul"
         },
         {
             "id": "USQX92506289",
@@ -19017,9 +17735,7 @@
                     "id": "16hJb6Q1lb22hVc4IsJoCo"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM5BK1900725",
@@ -19045,9 +17761,7 @@
                     "id": "1ILW9DXQGKm3IQRbetzDrM"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "NZUM72500024",
@@ -19073,9 +17787,7 @@
                     "id": "6FRKxwDHTDGr1lqQ0SEprH"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBHLW2501531",
@@ -19100,10 +17812,7 @@
                     "id": "6oaajUONqaImKe2Gc9oE2b"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Punk"
-            ]
+            "genres": "Egg Punk"
         },
         {
             "id": "QZ3AK2500010",
@@ -19132,9 +17841,7 @@
                     "url": "https://kassivalazza.bandcamp.com/track/weight-of-the-wheel"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "US3DF2514822",
@@ -19160,10 +17867,7 @@
                     "id": "4oB8Xd7gMlUEtWoD8bmCXW"
                 }
             },
-            "genres": [
-                "M\u00fasica Mexicana",
-                "Latin"
-            ]
+            "genres": "Corrido"
         },
         {
             "id": "FR9W12437323",
@@ -19189,10 +17893,7 @@
                     "id": "0NH6yKue0LAEc0MitqOmwx"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Singer/Songwriter"
-            ]
+            "genres": "Experimental Jazz"
         },
         {
             "id": "GBBPW2502098",
@@ -19218,10 +17919,7 @@
                     "id": "2NJDGk8pc3f7f3FisD7YKu"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Alternative"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "QT25Y2400003",
@@ -19246,9 +17944,7 @@
                     "id": "6qEhqLzsiYzipyTdOR0YKe"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Post-Hardcore"
         },
         {
             "id": "USRC12500849",
@@ -19274,9 +17970,7 @@
                     "id": "5dUCixiCL0CcIUdlgUl1ct"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USTJ22562902",
@@ -19302,10 +17996,7 @@
                     "id": "40rE8O0fEkaMjDpEpUDE72"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Sludge Metal"
         },
         {
             "id": "FRX452540493",
@@ -19330,9 +18021,7 @@
                     "id": "1RnaZq4I3JIkzxRAlTQsv8"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "USMRG2586905",
@@ -19358,10 +18047,7 @@
                     "id": "0yzIr8JB1jI78nP3KFtXVi"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "UKMD42500032",
@@ -19387,9 +18073,7 @@
                     "id": "1uIRlFoNdyc8CBBBXFO9Yk"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USUM72509143",
@@ -19415,9 +18099,7 @@
                     "id": "7wV5to0AMAWttuxTeTUzjP"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBBRP2501366",
@@ -19443,9 +18125,7 @@
                     "id": "0TR6bZ12pF2qC0XqpuXYkY"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QT3EZ2466098",
@@ -19470,9 +18150,7 @@
                     "id": "0r0vefzAdFKRAHTPTfz5f1"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "GBBRP2501367",
@@ -19498,9 +18176,7 @@
                     "id": "15U5ilubQiS4aiiFO3zuZE"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "AR4PD2500005",
@@ -19526,9 +18202,7 @@
                     "id": "5RDnvWoNADi1p9FFKSF9UH"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "US23A1592865",
@@ -19554,10 +18228,7 @@
                     "id": "1c7tRNPQtflMTHSGiQ4Kfo"
                 }
             },
-            "genres": [
-                "Classical",
-                "Piano"
-            ]
+            "genres": "Classical Piano"
         },
         {
             "id": "USSM12501141",
@@ -19583,9 +18254,7 @@
                     "id": "0BWJp4pLRHFVKJmDEIlrVn"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B"
         },
         {
             "id": "USA2P2522761",
@@ -19611,9 +18280,7 @@
                     "id": "6okV8XV4EFSxpVnP0zM2vF"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "QZZEB2457127",
@@ -19639,10 +18306,7 @@
                     "id": "5eCp47PfcZy61mDNdCZz1X"
                 }
             },
-            "genres": [
-                "Modern Dancehall",
-                "Reggae"
-            ]
+            "genres": "Soca"
         },
         {
             "id": "GBCFB2500037",
@@ -19668,9 +18332,7 @@
                     "id": "7BXa6HC5lF5HsZsWvOfTll"
                 }
             },
-            "genres": [
-                "Jazz"
-            ]
+            "genres": "Jazz"
         },
         {
             "id": "QZR8K2525007",
@@ -19696,9 +18358,7 @@
                     "id": "5KpCKUZAtQ47udFS7iL2GG"
                 }
             },
-            "genres": [
-                "Jazz"
-            ]
+            "genres": "Jazz"
         },
         {
             "id": "QM84B2596005",
@@ -19724,10 +18384,7 @@
                     "id": "3L0Rhwoqzo3vkvazlg7iml"
                 }
             },
-            "genres": [
-                "Jazz",
-                "R&B/Soul"
-            ]
+            "genres": "Experimental Jazz"
         },
         {
             "id": "DEB332284806",
@@ -19753,9 +18410,7 @@
                     "id": "7oXSZE2uUBQNrFciE3SYF5"
                 }
             },
-            "genres": [
-                "Classical"
-            ]
+            "genres": "Baroque"
         },
         {
             "id": "QMDA62414210",
@@ -19781,9 +18436,7 @@
                     "id": "1ih5mv61q3ls0gjCfq8mc2"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USUG12500947",
@@ -19809,9 +18462,7 @@
                     "id": "29ih3bl2AvGOhfZ4TpZWne"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "DEU162507153",
@@ -19837,9 +18488,7 @@
                     "id": "1dcqHqkAeRAQr8SJcL5sIu"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Jangle Pop"
         },
         {
             "id": "USATO2400521",
@@ -19865,10 +18514,7 @@
                     "id": "2yqQFMqf5gDz128rSn5rIF"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Rock y Alternativo"
         },
         {
             "id": "FRIDO2510695",
@@ -19894,10 +18540,7 @@
                     "id": "0gr9ny9UGmMdrBV1ivgnGb"
                 }
             },
-            "genres": [
-                "Jazz",
-                "R&B/Soul"
-            ]
+            "genres": "Nu Jazz"
         },
         {
             "id": "USWB12405406",
@@ -19923,10 +18566,7 @@
                     "id": "24fwLB47pPPSnMTs9Q3jHj"
                 }
             },
-            "genres": [
-                "Urbano latino",
-                "Latin"
-            ]
+            "genres": "Neoperreo"
         },
         {
             "id": "QMFME2597230",
@@ -19952,9 +18592,7 @@
                     "id": "1pIztA2k0YEP1wXBXx84wM"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Electronic"
         },
         {
             "id": "QMFME2412237",
@@ -19980,9 +18618,7 @@
                     "id": "2UYMqEc8YckMucNfU6z7nc"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USC4R2558311",
@@ -20008,9 +18644,7 @@
                     "id": "5CVH4yjJy1Nhr1G51UBG7e"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USSUB2466504",
@@ -20036,10 +18670,7 @@
                     "id": "1W8DLum7yPDyIS3TYjWIGO"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUM72509046",
@@ -20065,9 +18696,7 @@
                     "id": "7eCAw2VS0UhbsiSItwWdvl"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B"
         },
         {
             "id": "INY092500014",
@@ -20093,10 +18722,7 @@
                     "id": "5SSZtFWdrmFV4MxtlRA13N"
                 }
             },
-            "genres": [
-                "Bollywood",
-                "Indian"
-            ]
+            "genres": "Bollywood"
         },
         {
             "id": "DEB332178001",
@@ -20122,10 +18748,7 @@
                     "id": "27sawTG6Xm91X7Wn06AwWI"
                 }
             },
-            "genres": [
-                "Classical",
-                "Choral"
-            ]
+            "genres": "Minimalism"
         },
         {
             "id": "QM5ZK2500003",
@@ -20151,10 +18774,7 @@
                     "id": "2qXccbob5VYKTZ3D1nVIlp"
                 }
             },
-            "genres": [
-                "Soundtrack",
-                "Singer/Songwriter"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "USC4R2452200",
@@ -20180,10 +18800,7 @@
                     "id": "4mYAxNUCvuUqAQj5Qh3Poq"
                 }
             },
-            "genres": [
-                "Soul",
-                "R&B/Soul"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "USUM72503315",
@@ -20209,9 +18826,7 @@
                     "id": "6QN5ClFa3Ul4kFzsdw3Z8t"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "US5022500034",
@@ -20237,10 +18852,7 @@
                     "id": "1qB1YwUoz2xrk18SoejACp"
                 }
             },
-            "genres": [
-                "Latin",
-                "Alternative"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "QZZ8A2582180",
@@ -20266,10 +18878,7 @@
                     "id": "3GRimmgSiA1Dgh2B9P1HTZ"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Latin Indie"
         },
         {
             "id": "USUM72414560",
@@ -20295,9 +18904,7 @@
                     "id": "6KImrdTSnqqD5Pmfj0mjcz"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Traditional Country"
         },
         {
             "id": "USRC12500746",
@@ -20323,10 +18930,7 @@
                     "id": "5AvrkGFKSu7Hj66y7BPiBE"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USJ5G2536702",
@@ -20352,9 +18956,7 @@
                     "id": "0f8aTAJ49LTQStXC6BB2uw"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Retro Soul"
         },
         {
             "id": "QT4K32501558",
@@ -20380,10 +18982,7 @@
                     "id": "7K7yIe5w41Fk8ndI1DDwu0"
                 }
             },
-            "genres": [
-                "Contemporary Jazz",
-                "Jazz"
-            ]
+            "genres": "Jazz"
         },
         {
             "id": "QT3FA2592483",
@@ -20409,10 +19008,7 @@
                     "id": "5UDJO7XT3AywHB3gGotlfn"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Dance"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "USK112530113",
@@ -20438,10 +19034,7 @@
                     "id": "6jazPnayM84A0iELuIrvy8"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Jangle Pop"
         },
         {
             "id": "QM24S2505389",
@@ -20467,9 +19060,7 @@
                     "id": "3C6s0G3TW6VBEvZMZWhD6f"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USUG12500622",
@@ -20495,9 +19086,7 @@
                     "id": "1V48XXuIxK1jIpVoTI4aqn"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "USA2P2502966",
@@ -20523,9 +19112,7 @@
                     "id": "22I9OYOLQPVQOZpr3daoaz"
                 }
             },
-            "genres": [
-                "Arabic"
-            ]
+            "genres": "Arabic Hip Hop"
         },
         {
             "id": "USJZA2550202",
@@ -20551,9 +19138,7 @@
                     "id": "46ik88q0awURfYD4NAuuKM"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USC4R2552978",
@@ -20579,9 +19164,7 @@
                     "id": "0H1wDrRjC8VBO0mQNwQM9l"
                 }
             },
-            "genres": [
-                "Blues"
-            ]
+            "genres": "Blues"
         },
         {
             "id": "GBBKS2400380",
@@ -20629,10 +19212,7 @@
                     "id": "3HgSn2nlDVwnvlStwaA19M"
                 }
             },
-            "genres": [
-                "Modern Dancehall",
-                "Reggae"
-            ]
+            "genres": "Soca"
         },
         {
             "id": "GBBBA2500001",
@@ -20658,9 +19238,7 @@
                     "id": "2P362P669T4HGZQeFVucgO"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Neoclassical"
         },
         {
             "id": "GBMEF2502617",
@@ -20686,10 +19264,7 @@
                     "id": "1lMzRNvQfaZ964LSneGOzc"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Jazz"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "QMB622422317",
@@ -20715,10 +19290,7 @@
                     "id": "2SyimHymIiWH0crMcyT7Lt"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Pop"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USA2B2512531",
@@ -20744,10 +19316,7 @@
                     "id": "4AvGbMjGVkqC8Kmxn6EUQP"
                 }
             },
-            "genres": [
-                "Folk",
-                "Country"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "QMKRW2500097",
@@ -20773,9 +19342,7 @@
                     "id": "4tRs24qn4k5XJ4A9neXPEe"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USA2B2512584",
@@ -20801,10 +19368,7 @@
                     "id": "4sKWDLQiPel0R6sAkWF0tk"
                 }
             },
-            "genres": [
-                "Folk",
-                "Country"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "USUG12504614",
@@ -20830,9 +19394,7 @@
                     "id": "6VMFoZXQPfDKLq9bX9i0Q4"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USUG12506178",
@@ -20858,9 +19420,7 @@
                     "id": "4ZZJ7S4Z1pEIvTUgN1oRzS"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZTVM2515636",
@@ -20886,9 +19446,7 @@
                     "id": "2UDS0XpaqKrMv7wbVtWIlX"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USRO22505029",
@@ -20914,10 +19472,7 @@
                     "id": "7EQhvDdN2fyDHm5OQyCKfz"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative Folk"
         },
         {
             "id": "US3JJ2501192",
@@ -20943,10 +19498,7 @@
                     "id": "0DPDLv364qNKdKY8XZORsW"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Christian Lo-Fi"
         },
         {
             "id": "CA0RZ2500044",
@@ -20972,10 +19524,7 @@
                     "id": "3ZIUgIKpnUgCubcGx02oYn"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GXA9Z2400033",
@@ -21001,9 +19550,7 @@
                     "id": "725UQBe7B0hNAAlB8G0ni3"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QMFMF2446752",
@@ -21029,10 +19576,7 @@
                     "id": "470gEf45gAhLewLVc5IkKJ"
                 }
             },
-            "genres": [
-                "Neo-Soul",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USQX92503384",
@@ -21058,10 +19602,7 @@
                     "id": "7lZAVKwXTXcxp2RPF1R2U6"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "QZVM32200411",
@@ -21087,9 +19628,7 @@
                     "id": "1iX31GXHssJ7YETdIPuCCS"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "US2S72504007",
@@ -21115,10 +19654,7 @@
                     "id": "2CUNyfC2gWwdPr1SffaXtN"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Indie Soul"
         },
         {
             "id": "QZZ8B2466772",
@@ -21144,10 +19680,7 @@
                     "id": "53RjACGjiYw1SathAyoFuy"
                 }
             },
-            "genres": [
-                "Vocal Jazz",
-                "Jazz"
-            ]
+            "genres": "Vocal Jazz"
         },
         {
             "id": "US38W2449803",
@@ -21173,9 +19706,7 @@
                     "id": "7lbbOGDYKIqpcWHdJlfvqJ"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "QM4TW2517493",
@@ -21201,10 +19732,7 @@
                     "id": "05n0mwlh1y3cwjGmHnfVjh"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "USAT22401137",
@@ -21230,10 +19758,7 @@
                     "id": "4WFgvKVfEhb3IUAFGrutTR"
                 }
             },
-            "genres": [
-                "Contemporary R&B",
-                "R&B/Soul"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USEP42515003",
@@ -21259,9 +19784,7 @@
                     "id": "2N0e3WdwtkeDSAC8sqvP9a"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "DETP62400105",
@@ -21287,9 +19810,7 @@
                     "id": "7bu6uhjZ07Qm4sMq1Ooecp"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "USC4R2448882",
@@ -21315,9 +19836,7 @@
                     "id": "3fmUDp9n9ulLqFRDrbzSnK"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZFZ32565847",
@@ -21343,9 +19862,7 @@
                     "id": "6dXdZKMIWP78xQg2aMl89C"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "QMDA62591825",
@@ -21371,9 +19888,7 @@
                     "id": "5oPlmrWQ9QcFvZKWFOaWW7"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "East Coast Hip Hop"
         },
         {
             "id": "USUM72501915",
@@ -21399,9 +19914,7 @@
                     "id": "1YRbAonLvmuUILvQso0gUM"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMB622504512",
@@ -21427,10 +19940,7 @@
                     "id": "6h8nLmwNxWrHKYm9p28oc2"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZXD92300153",
@@ -21456,10 +19966,7 @@
                     "id": "32SJM4tQyJHsB8rgVtZURn"
                 }
             },
-            "genres": [
-                "Urbano latino",
-                "Latin"
-            ]
+            "genres": "Trap Latino"
         },
         {
             "id": "USUM72502294",
@@ -21484,9 +19991,7 @@
                     "id": "4uoADk7q83CHvXHW3k1etM"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rage Rap"
         },
         {
             "id": "DED620072931",
@@ -21512,9 +20017,7 @@
                     "id": "06nhoOF0GViBt0LUWyCTNA"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Jazz Rap"
         },
         {
             "id": "GBBKS2500060",
@@ -21562,10 +20065,7 @@
                     "id": "6YE0zn10XApgoCMaFeSj7b"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Synthpop"
         },
         {
             "id": "USHR22514801",
@@ -21591,10 +20091,7 @@
                     "id": "6UnNEuFWKFJuFSTemEs605"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Riot Grrrl"
         },
         {
             "id": "USY6C2544707",
@@ -21620,10 +20117,7 @@
                     "id": "4H512sUGwagrnMGNoO6wmN"
                 }
             },
-            "genres": [
-                "Electronic",
-                "IDM/Experimental"
-            ]
+            "genres": "Free Jazz"
         },
         {
             "id": "GBAFL2500468",
@@ -21646,10 +20140,7 @@
                     "id": "70XPjbjd54jY4YbTOo1SVY"
                 }
             },
-            "genres": [
-                "Post-Punk",
-                "Spoken Word"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "GBE5X2510247",
@@ -21674,10 +20165,7 @@
                     "id": "41oiTiyHxOFSy8dXK3pQyb"
                 }
             },
-            "genres": [
-                "Dance",
-                "Techno"
-            ]
+            "genres": "Industrial"
         },
         {
             "id": "USUG12501810",
@@ -21703,9 +20191,7 @@
                     "id": "7lj0vXLgWbyB0BvCsk22hn"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMB622502308",
@@ -21731,9 +20217,7 @@
                     "id": "5wlbrG0V3fuAlfLdH7EttL"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USL4R2454138",
@@ -21759,10 +20243,7 @@
                     "id": "4CpTehJ87nNwGCIJrSybkS"
                 }
             },
-            "genres": [
-                "Prog-Rock/Art Rock",
-                "Rock"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "QT3EZ2466101",
@@ -21788,9 +20269,7 @@
                     "id": "0RO1bV3EWlgG8atze1u0Xq"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "QZNMU2421699",
@@ -21816,9 +20295,7 @@
                     "id": "3neOwym9kfYsM1QWaR77C1"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Southern Hip Hop"
         },
         {
             "id": "USRC12501798",
@@ -21844,9 +20321,7 @@
                     "id": "6IBTI6u7tVNtWojUHnO4Ap"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USQX92501665",
@@ -21872,9 +20347,7 @@
                     "id": "5kUXTPwxC6ZkduukaukCRT"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZ2L62500000",
@@ -21900,10 +20373,7 @@
                     "id": "0w5t8iJ6RVCBWFgePi7uiU"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Retro Soul"
         },
         {
             "id": "US27Q2561909",
@@ -21929,10 +20399,7 @@
                     "id": "2YXDguAdOrvWYIwbPjvAkA"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USMTD2500174",
@@ -21955,9 +20422,7 @@
                     "id": "6YFrPFpWtluSdbafipRxiS"
                 }
             },
-            "genres": [
-                "Lo-Fi Indie"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
             "id": "USYBL2500011",
@@ -21983,10 +20448,7 @@
                     "id": "5p9JMOuMlYLDtfWtzW23v6"
                 }
             },
-            "genres": [
-                "Techno",
-                "Dance"
-            ]
+            "genres": "Dub Techno"
         },
         {
             "id": "QZVM32200352",
@@ -22012,9 +20474,7 @@
                     "id": "6Y16szIjrhu91wNbHTDqhX"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "NLA322500055",
@@ -22037,10 +20497,7 @@
                     "id": "6PaSOin7Y9GnXRZ5U5sMsv"
                 }
             },
-            "genres": [
-                "Hardcore Punk",
-                "Hardcore"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "GBARL2500424",
@@ -22066,9 +20523,7 @@
                     "id": "1z0gNe6DiusPKN55RBAvRO"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "UK R&B"
         },
         {
             "id": "USQX92502917",
@@ -22094,9 +20549,7 @@
                     "id": "4Km9FSF9iaQiTLnFPdbPom"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QMHBS2400208",
@@ -22122,9 +20575,7 @@
                     "id": "60gQmNkGCHQEb4TaJC9IwC"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "GXHAF2589303",
@@ -22150,9 +20601,7 @@
                     "id": "1jHFs6W5atp1hP0EhNmaZ3"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USSM12509701",
@@ -22178,10 +20627,7 @@
                     "id": "46o2qUuuuftFaeo6yHsyI1"
                 }
             },
-            "genres": [
-                "Singer/Songwriter",
-                "Pop"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "GBQCP2500133",
@@ -22207,10 +20653,7 @@
                     "id": "3WFinnHQKSEhVOZmYNR0Kd"
                 }
             },
-            "genres": [
-                "Adult Alternative",
-                "Rock"
-            ]
+            "genres": "Britpop"
         },
         {
             "id": "GBCEL2400960",
@@ -22236,9 +20679,7 @@
                     "id": "4KVYz4U1Vm3pvjhhhS1E6s"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "USUG12506966",
@@ -22264,9 +20705,7 @@
                     "id": "77tp1Yy4gys1k5bDtUygfu"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "GB5KW2500218",
@@ -22292,9 +20731,7 @@
                     "id": "4J1xDjTOAxqpFxaRtd4zh6"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USBQU2500079",
@@ -22320,9 +20757,7 @@
                     "id": "4gXvwRoP7GYoipYRTXQUxW"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USUG12409111",
@@ -22348,9 +20783,7 @@
                     "id": "2u6VEZjUu5P3GVfUMDIIbu"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSUB2559503",
@@ -22376,9 +20809,7 @@
                     "id": "13UDyEmTT5uWXZgq1TdCFA"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBUM72401776",
@@ -22404,9 +20835,7 @@
                     "id": "6LbH57lWaf4JrqdKYyqz6J"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "USJ5G2542803",
@@ -22432,9 +20861,7 @@
                     "id": "5b7XNPJbJV5ncuFGoh9ZJy"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USRC12403001",
@@ -22460,9 +20887,7 @@
                     "id": "0B7tnohfi83RQquo2JRHrL"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "GBENL2404087",
@@ -22488,9 +20913,7 @@
                     "id": "0KN08YO4zGw8NCkCiaRkS9"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "US38Y2525384",
@@ -22516,9 +20939,7 @@
                     "id": "74Ya4KTyVdBkKn0grWGyDj"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USCO92585202",
@@ -22544,10 +20965,7 @@
                     "id": "6di4zDK4P0M904AjR4aVDx"
                 }
             },
-            "genres": [
-                "Americana",
-                "Country"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USATO2500155",
@@ -22573,10 +20991,7 @@
                     "id": "4Cc8WY4SZ8gYTx8aYYN96l"
                 }
             },
-            "genres": [
-                "Americana",
-                "Country"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "QZNWP2575007",
@@ -22602,9 +21017,7 @@
                     "id": "1iecQAfm1L6eoTnvxLEN61"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "USUG12506175",
@@ -22630,9 +21043,7 @@
                     "id": "01p5urrGw5fuFCcfT7PBgc"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZ8SH2506801",
@@ -22658,10 +21069,7 @@
                     "id": "7rpKFFRgEFbFD0H5SkiLfg"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USWB12502035",
@@ -22687,9 +21095,7 @@
                     "id": "3lXyvlMnee9RWoe0COt7S4"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "CAHL42511702",
@@ -22715,9 +21121,7 @@
                     "id": "1D6d3Yp27FQdxLD8b4iudy"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USJ5G2542807",
@@ -22743,9 +21147,7 @@
                     "id": "1o9KFXJkF6jBpIvd4rthsi"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QMRTJ2500310",
@@ -22771,10 +21173,7 @@
                     "id": "3XTjtCEfZ34xMua70IK01m"
                 }
             },
-            "genres": [
-                "Soca",
-                "Worldwide"
-            ]
+            "genres": "Soca"
         },
         {
             "id": "US3R42551706",
@@ -22800,9 +21199,7 @@
                     "id": "4p3ZHnh9AJuZeyJ93WooeI"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Dream Pop"
         },
         {
             "id": "QZ22D2400123",
@@ -22828,9 +21225,7 @@
                     "id": "2nMyXK7jOtqyeCLkgBmTvN"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "DGA0S2477631",
@@ -22856,10 +21251,7 @@
                     "id": "6Z4AJ6GVRjdjmbm4TK1Wca"
                 }
             },
-            "genres": [
-                "House",
-                "Dance"
-            ]
+            "genres": "House"
         },
         {
             "id": "USUG12502832",
@@ -22885,9 +21277,7 @@
                     "id": "4VJQplLkX6agarX99u0iDm"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "QMB622500902",
@@ -22913,10 +21303,7 @@
                     "id": "5JhA03j2Sg0ySVXCL5XwCi"
                 }
             },
-            "genres": [
-                "Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "GBAFL2400179",
@@ -22964,10 +21351,7 @@
                     "id": "1GpslorH7Gi64x8uodyvfO"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "USUM72412585",
@@ -22993,9 +21377,7 @@
                     "id": "4pNzBbGcqXofx8mLBPTeih"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GBAFL2400468",
@@ -23018,9 +21400,7 @@
                     "id": "5dlT0N2w7u89V3CTWLf5x0"
                 }
             },
-            "genres": [
-                "Art Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "QMHBS2400209",
@@ -23046,9 +21426,7 @@
                     "id": "3URnvhDLXtkLegFuTZHRcz"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USEP42540001",
@@ -23074,9 +21452,7 @@
                     "id": "51qSkFx8D2dyWERxGQ44My"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "FR0D02500002",
@@ -23102,10 +21478,7 @@
                     "id": "5WZL03aLF9GVNaa5Q6ATNe"
                 }
             },
-            "genres": [
-                "Disco",
-                "R&B/Soul"
-            ]
+            "genres": "Italo Disco"
         },
         {
             "id": "QMFMF2534729",
@@ -23131,9 +21504,7 @@
                     "id": "35OvmPX96d7f1ElQMl8Pq2"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USUG12501276",
@@ -23159,9 +21530,7 @@
                     "id": "3sZQ8L4aptFDJXBqdVdvO8"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Malayalam Hip Hop"
         },
         {
             "id": "QMCE72530003",
@@ -23187,10 +21556,7 @@
                     "id": "5DcTkTG3Z4uoQTxIv4LgPZ"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Punk"
         },
         {
             "id": "QZHNA2539332",
@@ -23219,10 +21585,7 @@
                     "url": "https://soundcloud.com/bmgmusix/stophatin"
                 }
             },
-            "genres": [
-                "Reggae",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "QM3DF2413965",
@@ -23248,10 +21611,7 @@
                     "id": "4eLDmhsJW3JoZTXCAozHor"
                 }
             },
-            "genres": [
-                "Urbano latino",
-                "Latin"
-            ]
+            "genres": "Corrido"
         },
         {
             "id": "GBBPW2401475",
@@ -23277,10 +21637,7 @@
                     "id": "5DbsGLA9hVVclF8g6KWYai"
                 }
             },
-            "genres": [
-                "R&B/Soul",
-                "Jazz"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "GBUM72407005",
@@ -23306,9 +21663,7 @@
                     "id": "5uXpQh7y6pqwoEbPgmjXCu"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "USA2B2512592",
@@ -23334,10 +21689,7 @@
                     "id": "5ZMx3OaX3quw7BlSt3dUZa"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Punk"
         },
         {
             "id": "USRC12500675",
@@ -23363,10 +21715,7 @@
                     "id": "0wew10FuXHnhlSmLXUpWdt"
                 }
             },
-            "genres": [
-                "Alternative",
-                "R&B/Soul"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "QZPKV2404903",
@@ -23392,10 +21741,7 @@
                     "id": "018flP7rUxOYjiccV8czwy"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Folk"
-            ]
+            "genres": "Ambient Folk"
         },
         {
             "id": "USA2P2539998",
@@ -23421,9 +21767,7 @@
                     "id": "2DQ4xJf4xm1Ho8yKQkOqgi"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Banda"
         },
         {
             "id": "GBBPW2401399",
@@ -23449,10 +21793,7 @@
                     "id": "1qCOC3y2zuswTq6PZoL2ID"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Electronic"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USUYG1580113",
@@ -23478,9 +21819,7 @@
                     "id": "5VHRiH48pBB008CAkrIBwP"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "NL8RL2462541",
@@ -23506,9 +21845,7 @@
                     "id": "2QE1HicP9V1gI9QY6eOCTu"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "DEMM42500050",
@@ -23534,9 +21871,7 @@
                     "id": "6HybzXJc5MO4GDfNuZIVcS"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Dub Techno"
         },
         {
             "id": "QM7282553930",
@@ -23562,9 +21897,7 @@
                     "id": "4l8t27aV3hDR55Dv7Nx7UX"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "US5TA2400376",
@@ -23590,10 +21923,7 @@
                     "id": "2YUUYGB1kMtXKTQ6ajAjTA"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "QZ8BZ2513511",
@@ -23618,10 +21948,7 @@
                     "id": "0MHStU0muAIEMbwdnebYu2"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "USUG12501623",
@@ -23647,9 +21974,7 @@
                     "id": "1BDLD4c07q0bmq2VCRsXoE"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USSM12501885",
@@ -23675,9 +22000,7 @@
                     "id": "4SNPg0KDZ859vauVTaNg7i"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USUM72509812",
@@ -23703,9 +22026,7 @@
                     "id": "7KO0PWYRvoQMNdOZ4KHulW"
                 }
             },
-            "genres": [
-                "R&B/Soul"
-            ]
+            "genres": "R&B/Soul"
         },
         {
             "id": "USEP42516004",
@@ -23731,9 +22052,7 @@
                     "id": "265oUq9rH0eV03CmMV0vmA"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Post-Hardcore"
         },
         {
             "id": "US3JJ2501232",
@@ -23759,9 +22078,7 @@
                     "id": "55JAgc5FHJNW5WvNAFzBcW"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Riot Grrrl"
         },
         {
             "id": "QM84B2599001",
@@ -23787,9 +22104,7 @@
                     "id": "4AeEJMj92wcssAFjPLtVMY"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Post-Rock"
         },
         {
             "id": "GBBKS2500081",
@@ -23812,10 +22127,7 @@
                     "id": "4kd3HIkMbwO4sVgkYkrBGo"
                 }
             },
-            "genres": [
-                "Idm",
-                "Electronica"
-            ]
+            "genres": "IDM"
         },
         {
             "id": "QM6MZ2511784",
@@ -23841,9 +22153,7 @@
                     "id": "1td8l5TOZLYUS6znwstHcL"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Power Pop"
         },
         {
             "id": "QM7282553926",
@@ -23869,10 +22179,7 @@
                     "id": "3PfA2PM8z6iO36CPOi7CHq"
                 }
             },
-            "genres": [
-                "Alternative Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "GBQLP2500258",
@@ -23898,10 +22205,7 @@
                     "id": "0Poy6PuvK8nrHDjkTtVusT"
                 }
             },
-            "genres": [
-                "Electronic",
-                "Electronica"
-            ]
+            "genres": "Drum And Bass"
         },
         {
             "id": "DED622500125",
@@ -23927,10 +22231,7 @@
                     "id": "1uaDFdd8tYV7m4EWH4Xq9l"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "QZHNC2510452",
@@ -23956,10 +22257,7 @@
                     "id": "3RC1QgJh7sFaWkFdFJMGS6"
                 }
             },
-            "genres": [
-                "Latin",
-                "Rock"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "USJ5G2442503",
@@ -23985,9 +22283,7 @@
                     "id": "5JVEWVNVv8OYILCkHZkwvK"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USAT22507200",
@@ -24010,10 +22306,7 @@
                     "id": "1nRWADK5ctY6x7zXg4eW8F"
                 }
             },
-            "genres": [
-                "Art Pop",
-                "Alternative R&B"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "GXC3L2500602",
@@ -24039,10 +22332,7 @@
                     "id": "0D9gTE3I7vhTdxyIgLTkJC"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "NZUM72500021",
@@ -24068,9 +22358,7 @@
                     "id": "01U0X0ToQhK0AgvNUdyXQe"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QZDA62588926",
@@ -24096,10 +22384,7 @@
                     "id": "01QN0DfaIrazVmGEfZ5RVX"
                 }
             },
-            "genres": [
-                "Country",
-                "Rock"
-            ]
+            "genres": "Country"
         },
         {
             "id": "US2U62539607",
@@ -24125,10 +22410,7 @@
                     "id": "5YZyIjrHPtmJBTBzauiH0Z"
                 }
             },
-            "genres": [
-                "Folk",
-                "Alternative"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "GBPVV2406283",
@@ -24154,9 +22436,7 @@
                     "id": "7wbGNuUZLrnzT0XpEuIw4g"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USSM12504035",
@@ -24182,10 +22462,7 @@
                     "id": "4oVO4fGNRRvEn0CRuFO4qv"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "US2U62540001",
@@ -24211,10 +22488,7 @@
                     "id": "5cvcTqLPUWGsJSz2m8GGeP"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "CBFVW2500003",
@@ -24240,9 +22514,7 @@
                     "id": "1nZDh3rmby6PXE7aDRsKTU"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USQX92406420",
@@ -24268,10 +22540,7 @@
                     "id": "0jaMR6KQ1voR8RHlZ7Pg4G"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "GBBKS2500059",
@@ -24319,9 +22588,7 @@
                     "id": "139nLHDFZNr3anx8CpUy7u"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "GBUM72501772",
@@ -24347,9 +22614,7 @@
                     "id": "1lHsjpIJ9aFOkz4w4yduzt"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QMB622506407",
@@ -24375,9 +22640,7 @@
                     "id": "33R1gmtNjLE1irIgiOCReb"
                 }
             },
-            "genres": [
-                "Folk"
-            ]
+            "genres": "Electroacoustic"
         },
         {
             "id": "QZRD92404862",
@@ -24403,9 +22666,7 @@
                     "id": "1osfLqL6L2iQsirRf83ded"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USMTD2400698",
@@ -24428,10 +22689,7 @@
                     "id": "1T6jzRht9aXUFukdOgZgIL"
                 }
             },
-            "genres": [
-                "Midwest Emo",
-                "Indie Rock"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "USWB12500844",
@@ -24457,9 +22715,7 @@
                     "id": "2ipIPsgrgd0j2beDf4Ki70"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USA2P2507989",
@@ -24485,10 +22741,7 @@
                     "id": "1tI8Ubt5VEMWDoGL08pomF"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "USA2Z2500534",
@@ -24514,10 +22767,7 @@
                     "id": "5bYuSXpSeoXfrrZh3hjlG1"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Black Metal"
         },
         {
             "id": "QZTB22565659",
@@ -24543,10 +22793,7 @@
                     "id": "0JeZ5I1tRCVR3cnZ9FGYP8"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12504046",
@@ -24572,9 +22819,7 @@
                     "id": "0px4JlY1xjxoKqznyD4IPC"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "UKRNU2101041",
@@ -24600,10 +22845,7 @@
                     "id": "0fumix9cQVECmKsSbHWw58"
                 }
             },
-            "genres": [
-                "Punk",
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "QZZ782564179",
@@ -24629,10 +22871,7 @@
                     "id": "3uzkpsb3PqPz0KoVOV99no"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Pop"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBUM72501973",
@@ -24658,9 +22897,7 @@
                     "id": "1adLrnw5jTY7BOJXuRoG0g"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "UK Garage"
         },
         {
             "id": "UKG3X2200352",
@@ -24686,10 +22923,7 @@
                     "id": "2ytshALEfnlzn9xV08Q9pD"
                 }
             },
-            "genres": [
-                "Indie Pop",
-                "Alternative"
-            ]
+            "genres": "Indie Pop"
         },
         {
             "id": "USSUB2457508",
@@ -24715,10 +22949,7 @@
                     "id": "1tlfzZlpVMLXhkEFL4bh7Z"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Electronic"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "US5022500035",
@@ -24744,10 +22975,7 @@
                     "id": "74eICpWmMuVmBtaOr3YqPN"
                 }
             },
-            "genres": [
-                "Latin",
-                "Alternative"
-            ]
+            "genres": "Latin"
         },
         {
             "id": "USMTD2400377",
@@ -24770,9 +22998,7 @@
                     "id": "6BEgnEWwpTm6AJ4mphJwsZ"
                 }
             },
-            "genres": [
-                "Art Pop"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "QM6P42533254",
@@ -24798,9 +23024,7 @@
                     "id": "0loAUwPeBd9LvYtnaKpoGG"
                 }
             },
-            "genres": [
-                "Electronic"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USMTD2400499",
@@ -24823,9 +23047,7 @@
                     "id": "5P5qbnKKR4wHhbnWncXsTt"
                 }
             },
-            "genres": [
-                "Downtempo"
-            ]
+            "genres": "Downtempo"
         },
         {
             "id": "AUVWE2401440",
@@ -24851,9 +23073,7 @@
                     "id": "5ueFHJVZSCptDmR8Re9yOT"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USRC12502004",
@@ -24879,9 +23099,7 @@
                     "id": "04a44cx2PJthIbN2aLMXhl"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM4TW2525817",
@@ -24907,9 +23125,7 @@
                     "id": "60jK1IQ31TzqtL1e0sHHda"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBDCA2404316",
@@ -24935,9 +23151,7 @@
                     "id": "76EPmtvdLUdH3ODgiwEjo4"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USAT22500010",
@@ -24963,10 +23177,7 @@
                     "id": "3zdMs3UPyhMUCmXOsbFzQ7"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Black Metal"
         },
         {
             "id": "GBGNS2200280",
@@ -24992,9 +23203,7 @@
                     "id": "7hpY7YGpDLMHQZOZYd52Vl"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USMTD2500202",
@@ -25017,10 +23226,7 @@
                     "id": "1SMdm0arRn2bXy1Uspa4OJ"
                 }
             },
-            "genres": [
-                "Art Rock",
-                "Art Pop"
-            ]
+            "genres": "Art Rock"
         },
         {
             "id": "USQX92503276",
@@ -25046,10 +23252,7 @@
                     "id": "45mVT3DCE7AATXgESSdfee"
                 }
             },
-            "genres": [
-                "Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Rap"
         },
         {
             "id": "USMTD2400197",
@@ -25075,10 +23278,7 @@
                     "url": "https://circuitdesyeux.bandcamp.com/track/canopy-of-eden-1"
                 }
             },
-            "genres": [
-                "Slowcore",
-                "Art Pop"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "USSM12500766",
@@ -25104,9 +23304,7 @@
                     "id": "0rgwADAHd21s1OE7RPFwPN"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QMB622506109",
@@ -25132,10 +23330,7 @@
                     "id": "0sLPXoUB1Q1gQcs1OOYy49"
                 }
             },
-            "genres": [
-                "Country",
-                "Rock"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "QMB622401112",
@@ -25161,9 +23356,7 @@
                     "id": "0sUJVa3AFcEqdy11QtiZCY"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USC4R2553064",
@@ -25189,9 +23382,7 @@
                     "id": "2TqQMPjKGzaZUcuLBCkuL2"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QZWH32400054",
@@ -25217,10 +23408,7 @@
                     "id": "3t6gUcGYLrUuqwpXjOFWQc"
                 }
             },
-            "genres": [
-                "Traditional Country",
-                "Country"
-            ]
+            "genres": "Country"
         },
         {
             "id": "USJZA2551101",
@@ -25246,9 +23434,7 @@
                     "id": "2QNzWVqj2YWd8ZuBY7KZeA"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USNO12500180",
@@ -25274,9 +23460,7 @@
                     "id": "3kz5XjngoS57hV9rU2gRH6"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Bluegrass"
         },
         {
             "id": "GBBPW2501490",
@@ -25302,9 +23486,7 @@
                     "id": "0IRtsYqlZrATSdxuRS90Ip"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USA2P2551925",
@@ -25330,9 +23512,7 @@
                     "id": "7zuTE1Eah3KFnYb6ybC1dB"
                 }
             },
-            "genres": [
-                "Singer/Songwriter"
-            ]
+            "genres": "Singer/Songwriter"
         },
         {
             "id": "QZNVN2410001",
@@ -25358,10 +23538,7 @@
                     "id": "2DLZwV6ZyP8wuECN7UjD4Z"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "QM6N22553527",
@@ -25387,9 +23564,7 @@
                     "id": "4nwjvcUjV7cexhwA40Bh5i"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USWB12500365",
@@ -25415,9 +23590,7 @@
                     "id": "6NBiRxb2ydIWmlFuuxpOhW"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hyphy"
         },
         {
             "id": "QMRSZ2402027",
@@ -25443,10 +23616,7 @@
                     "id": "2wwxE7Ww8UfcDtXCiLlnsB"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Metalcore"
         },
         {
             "id": "NL8RL2502403",
@@ -25472,9 +23642,7 @@
                     "id": "2oINmoPkPxKc2QATOiA0u9"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Sexy Drill"
         },
         {
             "id": "GBBKS2500116",
@@ -25497,9 +23665,7 @@
                     "id": "5ZkjTRSa7Ha2cf29okELYh"
                 }
             },
-            "genres": [
-                "Alternative R&B"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "USUG12504249",
@@ -25525,9 +23691,7 @@
                     "id": "6GniZoAv7dAL3djoMjxVZa"
                 }
             },
-            "genres": [
-                "Country"
-            ]
+            "genres": "Americana"
         },
         {
             "id": "MXA4M2500036",
@@ -25553,10 +23717,7 @@
                     "id": "6uroNiDEDd0xFLiri0aQNk"
                 }
             },
-            "genres": [
-                "Urbano latino",
-                "Latin"
-            ]
+            "genres": "Electro Corridos"
         },
         {
             "id": "QZ8BZ2513512",
@@ -25582,10 +23743,7 @@
                     "id": "1I37Zz2g3hk9eWxaNkj031"
                 }
             },
-            "genres": [
-                "K-Pop",
-                "Pop"
-            ]
+            "genres": "K-Pop"
         },
         {
             "id": "QZ8SH2405209",
@@ -25611,9 +23769,7 @@
                     "id": "1HaNDMAJjsEinenk205n4P"
                 }
             },
-            "genres": [
-                "Folk"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "QZR8K2441020",
@@ -25639,10 +23795,7 @@
                     "id": "0kFv6QchgZrrbd7mPP5QrU"
                 }
             },
-            "genres": [
-                "Pop",
-                "Alternative"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USEP42441001",
@@ -25668,9 +23821,7 @@
                     "id": "7leOfpblnwIyAqr2u4hNZE"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USEP42515001",
@@ -25696,9 +23847,7 @@
                     "id": "5BlGwkHjJHXa7ssaElVmYt"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
         },
         {
             "id": "USCO92585408",
@@ -25724,10 +23873,7 @@
                     "id": "5S9Fp2B0AOyURvKnnNRuQe"
                 }
             },
-            "genres": [
-                "Bluegrass",
-                "Country"
-            ]
+            "genres": "Bluegrass"
         },
         {
             "id": "NL7JW2400003",
@@ -25753,10 +23899,7 @@
                     "id": "3yAVjo24bbVBElLDlIO4fv"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "QZTBD2512996",
@@ -25782,9 +23925,7 @@
                     "id": "53gZyaUBzGwLyUKDc3sdJQ"
                 }
             },
-            "genres": [
-                "Latin"
-            ]
+            "genres": "Bedroom Pop"
         },
         {
             "id": "USAT22500463",
@@ -25810,9 +23951,7 @@
                     "id": "2RkZ5LkEzeHGRsmDqKwmaJ"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USMRG2586902",
@@ -25838,10 +23977,7 @@
                     "id": "7dfurNiPzlhmACURpes3HP"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "NLW3Q2400003",
@@ -25867,10 +24003,7 @@
                     "id": "0zWMaIuePlePcnjsPmHxxF"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "USSUB2465401",
@@ -25896,10 +24029,7 @@
                     "id": "5cwjNspmIDLehxMTfX2NIC"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Electronic"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QT3EY2541276",
@@ -25925,10 +24055,7 @@
                     "id": "1IO1X0d6SpveTXNOZI6T9j"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Alternative"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "USQX92502086",
@@ -25954,10 +24081,7 @@
                     "id": "0XfwXFXOI7oys9rsZ2sjrt"
                 }
             },
-            "genres": [
-                "Soundtrack",
-                "Pop"
-            ]
+            "genres": "Southern Gothic"
         },
         {
             "id": "USA2Z2500341",
@@ -25983,10 +24107,7 @@
                     "url": "https://purplishrecords.bandcamp.com/track/amidinin"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUM72504709",
@@ -26012,9 +24133,7 @@
                     "id": "44t9rTRjK82lBbZwuePQOE"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USSM12503928",
@@ -26040,10 +24159,7 @@
                     "id": "3ScIZdvkqGTrhW4hZDIL00"
                 }
             },
-            "genres": [
-                "Metal",
-                "Rock"
-            ]
+            "genres": "Groove Metal"
         },
         {
             "id": "DE1NZ2500011",
@@ -26069,9 +24185,7 @@
                     "id": "02KWhwsDjIX8ZXgBgK9kOP"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Soul"
         },
         {
             "id": "QMV8L2335309",
@@ -26097,10 +24211,7 @@
                     "id": "2MYs6hMDvXZ5U7tSCMEdIN"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Indie Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USAT22405520",
@@ -26126,9 +24237,7 @@
                     "id": "5ZgC4F4LfjZBBHZG4EOckr"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBCKK2578910",
@@ -26154,9 +24263,7 @@
                     "id": "5AYa3CrtYKuGRZqsIVgPlp"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "US5262527558",
@@ -26182,9 +24289,7 @@
                     "id": "3K85nEutdOPbJuAJgoe2O4"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "QM5WW1501251",
@@ -26210,9 +24315,7 @@
                     "id": "11zY7E1nQFu1dOgKwA25DB"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "CAN112500233",
@@ -26238,9 +24341,7 @@
                     "id": "39qhEfWsxkbhuRqs1cEfoX"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USATO2400341",
@@ -26266,9 +24367,7 @@
                     "id": "3q5poJRpLvVxdBVpsMTBMu"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Jam Band"
         },
         {
             "id": "USQX92505544",
@@ -26294,10 +24393,7 @@
                     "id": "0mQutndCp4cUXnrXZ9acHB"
                 }
             },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop"
         },
         {
             "id": "GBKZV2500049",
@@ -26323,9 +24419,7 @@
                     "id": "6aFN0owk4tiL8qXhx4IrOF"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "QZNWP2574102",
@@ -26351,9 +24445,7 @@
                     "id": "3CfXcxwbnrSH0AvZCMfLrO"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "US5NR2534701",
@@ -26379,10 +24471,7 @@
                     "id": "2EDBjvlWHKWNyHHWMWPx1j"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "USSM12501022",
@@ -26408,9 +24497,7 @@
                     "id": "2OBzYCYMNsD6yhBZZSs0xg"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QM6MZ2542636",
@@ -26436,9 +24523,7 @@
                     "id": "1EAadJeM4oPkNIYMjG8zDH"
                 }
             },
-            "genres": [
-                "Dance"
-            ]
+            "genres": "Electroclash"
         },
         {
             "id": "USA2B2513827",
@@ -26464,10 +24549,7 @@
                     "id": "7EdZ03QFAprOEHNUMZ7Z8v"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "QZDZE2508101",
@@ -26493,9 +24575,7 @@
                     "id": "1XciIcJvY7m3u8cq7toVlB"
                 }
             },
-            "genres": [
-                "Worldwide"
-            ]
+            "genres": "Worldwide"
         },
         {
             "id": "QZNWZ2562157",
@@ -26521,9 +24601,7 @@
                     "id": "1AoJo7BkqgPJCRCQCtJ2iY"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Noise Rock"
         },
         {
             "id": "QZZ7U2521736",
@@ -26549,9 +24627,7 @@
                     "id": "3k5Ecirq6FC4aWf2T7Sl7b"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "G-Funk"
         },
         {
             "id": "QZ5FA2550101",
@@ -26577,9 +24653,7 @@
                     "id": "1qbSjUjjKI0p0qRbUHaYTV"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Cloud Rap"
         },
         {
             "id": "QZAZS2410505",
@@ -26605,9 +24679,7 @@
                     "id": "4Bj1KgPvlZvr03fvBPJxiE"
                 }
             },
-            "genres": [
-                "Folk"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "USRC12502339",
@@ -26633,10 +24705,7 @@
                     "id": "0fKrZjwdZlwAEYi7S012mN"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Afrobeats"
         },
         {
             "id": "USY242467892",
@@ -26662,10 +24731,7 @@
                     "id": "04K5qfFqfxJF5yh3xaUYZS"
                 }
             },
-            "genres": [
-                "Alternative Folk",
-                "Singer/Songwriter"
-            ]
+            "genres": "Alternative Folk"
         },
         {
             "id": "USUM72504446",
@@ -26691,9 +24757,7 @@
                     "id": "0je57Uq5eTk1wrPzn9sWbl"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "QMCE72528002",
@@ -26719,10 +24783,7 @@
                     "id": "4qIVsBt7IZhz0YyWufXhrO"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Punk"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "USUG12505531",
@@ -26748,9 +24809,7 @@
                     "id": "06USX1htQD4LgOgX4FF0ix"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Industrial Rock"
         },
         {
             "id": "QM6N22532924",
@@ -26776,9 +24835,7 @@
                     "id": "5pLF4Gf07VZTg8QqX3wDHi"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USEP42522002",
@@ -26803,9 +24860,7 @@
                     "id": "6381d3dO3SzcI1mGY17wXq"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Midwest Emo"
         },
         {
             "id": "TCAJU2526815",
@@ -26831,10 +24886,7 @@
                     "id": "59pTfHqnksL9JHGbusHUiA"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Rock"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "QM4TX2588354",
@@ -26860,9 +24912,7 @@
                     "id": "04tKVEySP4qGEiXQ5EkXMI"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Alternative R&B"
         },
         {
             "id": "US38W2550308",
@@ -26888,9 +24938,7 @@
                     "id": "7dLMXmaRAEpXhuWLTv0iqL"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Dream Pop"
         },
         {
             "id": "QZFZ32598277",
@@ -26916,9 +24964,7 @@
                     "id": "7HN4SqrMZ30m4RWYm29gJv"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "USEZ62629003",
@@ -26944,10 +24990,7 @@
                     "id": "4OUXSMtGYH0Vacg7W6zCwS"
                 }
             },
-            "genres": [
-                "Rock",
-                "Electronic"
-            ]
+            "genres": "Queercore"
         },
         {
             "id": "QZTGW2406466",
@@ -26973,10 +25016,7 @@
                     "id": "30JRrogttGqqZj2wTxCHe8"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap",
-                "Electronic"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "UKQC92530004",
@@ -27001,9 +25041,7 @@
                     "id": "4uwdzhJ3WIStAyGpzLyZlb"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Slowcore"
         },
         {
             "id": "USUG12501595",
@@ -27029,9 +25067,7 @@
                     "id": "13vpSZ4nzZFBQNzmlR7HP2"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Hyperpop"
         },
         {
             "id": "QZMEP2501721",
@@ -27060,10 +25096,7 @@
                     "url": "https://creditrecordings.bandcamp.com/track/anywhere-2023-2024-2"
                 }
             },
-            "genres": [
-                "Rock",
-                "Singer/Songwriter"
-            ]
+            "genres": "Rock"
         },
         {
             "id": "USUM72505150",
@@ -27089,9 +25122,7 @@
                     "id": "3rGu21P8XTUi1PhqvKCTe1"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBBPW2401151",
@@ -27117,9 +25148,7 @@
                     "id": "6JrtUQ97SQqVoMW5bWFd7I"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Post-Punk"
         },
         {
             "id": "USFP13785203",
@@ -27145,9 +25174,7 @@
                     "id": "4RUyxhyD0U1nJEYGex9k98"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Indie Folk"
         },
         {
             "id": "USN2F2400054",
@@ -27173,9 +25200,7 @@
                     "id": "5dhCaTX2DKPcUgY5VhlC4R"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6N22436522",
@@ -27201,10 +25226,7 @@
                     "id": "3lf4HoJOhYrSKts3ohKUmT"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USUM72508503",
@@ -27230,9 +25252,7 @@
                     "id": "73EKQrgYNVwOaKdwh5a1PV"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Hip-Hop/Rap"
         },
         {
             "id": "DEG932501950",
@@ -27258,10 +25278,7 @@
                     "id": "2dexrJhfT8hQEvH7uqNpRf"
                 }
             },
-            "genres": [
-                "Folk",
-                "Alternative"
-            ]
+            "genres": "Folk"
         },
         {
             "id": "QM7282553923",
@@ -27286,10 +25303,7 @@
                     "id": "1iuQNv9Jbn0zYlYeJm85f1"
                 }
             },
-            "genres": [
-                "Alternative Rap",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Experimental Hip Hop"
         },
         {
             "id": "QZ22D2400128",
@@ -27314,9 +25328,7 @@
                     "id": "55abDFBW5pPb1HjYvIapEa"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USMTD2400264",
@@ -27339,9 +25351,7 @@
                     "id": "1SFVei3ZUf3EuJdvKqmGKv"
                 }
             },
-            "genres": [
-                "Lo-Fi Indie"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
             "id": "USMTD2400408",
@@ -27364,9 +25374,7 @@
                     "id": "27fkRoVhHpHBKsDLZnC9my"
                 }
             },
-            "genres": [
-                "Ambient Folk"
-            ]
+            "genres": "Ambient Folk"
         },
         {
             "id": "UKQNV2500022",
@@ -27392,9 +25400,7 @@
                     "id": "7CK4bpTIiYWYp478jgSlgp"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Art Pop"
         },
         {
             "id": "US3R42550803",
@@ -27420,10 +25426,7 @@
                     "id": "24uUPnVhCzhpFYlqZDrhN3"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Vocaloid"
         },
         {
             "id": "QZNVN2410004",
@@ -27449,10 +25452,7 @@
                     "id": "4MtXbKTXoT5t8GTwVCYzvY"
                 }
             },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
+            "genres": "Indie Rock"
         },
         {
             "id": "QM4TX2504662",
@@ -27478,9 +25478,7 @@
                     "id": "4jp9Es2eqWIZZyrEIir7zu"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "QM6P42420592",
@@ -27506,9 +25504,7 @@
                     "id": "3IFk55tJwqBrdhgsLvrVvn"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USRC12501001",
@@ -27534,10 +25530,7 @@
                     "id": "0mxBL9v4xZM0q4GAhJWbHB"
                 }
             },
-            "genres": [
-                "Alternative",
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USJ5G2535804",
@@ -27563,9 +25556,7 @@
                     "id": "3Dv3zgW4OHauERx9RIZUXL"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Hardcore Punk"
         },
         {
             "id": "GBCFB2500215",
@@ -27591,9 +25582,7 @@
                     "id": "5WRdonm8caliL2JA6fT2fL"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "GBCKC2500059",
@@ -27619,9 +25608,7 @@
                     "id": "3g0xd9m1MxKRiIC2Xw4998"
                 }
             },
-            "genres": [
-                "Rock"
-            ]
+            "genres": "Post-Rock"
         },
         {
             "id": "GBUM72403261",
@@ -27647,9 +25634,7 @@
                     "id": "5lQS3Q71OZWEA2tt7TcWai"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USUG12506437",
@@ -27675,9 +25660,7 @@
                     "id": "1jgTiNob5cVyXeJ3WgX5bL"
                 }
             },
-            "genres": [
-                "Pop"
-            ]
+            "genres": "Pop"
         },
         {
             "id": "USEZ62527803",
@@ -27703,10 +25686,7 @@
                     "id": "2RTlcEKqNPoJmLExbKMmqz"
                 }
             },
-            "genres": [
-                "Rock",
-                "Alternative"
-            ]
+            "genres": "Shoegaze"
         },
         {
             "id": "USBQU2500195",
@@ -27732,9 +25712,7 @@
                     "id": "6uRp0phyIJbLCYcefThba2"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alternative"
         },
         {
             "id": "USSM12504031",
@@ -27760,10 +25738,7 @@
                     "id": "2JH26hQtnqWUNnQET8o2N1"
                 }
             },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
+            "genres": "Latin"
         }
     ]
 }

--- a/index.html
+++ b/index.html
@@ -172,6 +172,14 @@
         width: 100%; /* Ensure it takes full width in stack */
       }
 
+      /* Genre display styling - use specific selector to override Pico's h5 styles */
+      article.song-card hgroup h5.song-genres {
+        font-size: 0.8rem;
+        opacity: 65%;
+        font-weight: 300; /* Lighter weight creates a sophisticated look */
+        margin-bottom: 0;
+      }
+
       .about-methodology-box {
         background: var(--pico-card-background-color);
         padding: var(--pico-spacing);
@@ -266,9 +274,9 @@
 
       /* Use h4 for artist name in hgroup */
       article.song-card hgroup h4 {
-        margin-bottom: 0;
         color: var(--pico-muted-color);
         font-weight: normal;
+        margin-bottom: 0.25rem
       }
 
       /* Info icon - now inside header, aligned to baseline */

--- a/samples/sample_data.json
+++ b/samples/sample_data.json
@@ -256,423 +256,517 @@
     },
     "songs": [
         {
-            "id": "USUG12503807",
-            "artist": "YoungBoy Never Broke Again",
-            "name": "Shot Callin",
+            "id": "USSM12504030",
+            "artist": "ROSAL\u00cdA",
+            "name": "Reliquia",
             "sources": [
                 {
-                    "name": "Rolling Stone",
+                    "name": "Paste",
                     "rank": 7,
-                    "quote": "the track hits you like a gut punch with its explosive trap drums and YoungBoy's melodic and menacing delivery"
+                    "quote": "opening cascade of vibrant strings ... provides an opening for ROSAL\u00cdA to wax poetic on the trappings of fame"
                 },
                 {
-                    "name": "Complex",
+                    "name": "NME",
                     "rank": 7,
-                    "quote": "a generation-defining artist finally basking in well-earned glory"
+                    "quote": "its gorgeous opening string arrangement melting into gently thumping electronic production"
+                },
+                {
+                    "name": "Slant",
+                    "rank": 14,
+                    "quote": "projects a heavenly tranquility as she lists the sacrifices she's made for art and love"
                 }
             ],
-            "list_count": 2,
+            "list_count": 3,
             "media": {
                 "youtube": {
-                    "music_id": "XoqyAWcedvM",
-                    "video_id": "XoqyAWcedvM"
+                    "music_id": "QI2kMNHKC2M",
+                    "video_id": "xPaSuWrBAQI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shot-callin/1824363644?i=1824363817"
+                    "url": "https://music.apple.com/us/album/reliquia/1848167516?i=1848167522"
                 },
                 "spotify": {
-                    "id": "4n4tC4qO2LeWQRM9Gbbtop"
+                    "id": "4ORvXsPK9AJmDzm36BYcdy"
                 }
             },
-            "genres": [
-                "Hip-Hop/Rap"
-            ]
+            "genres": "Latin"
         },
         {
-            "id": "USRC12500972",
-            "artist": "Doja Cat",
-            "name": "Jealous Type",
+            "id": "FRX452505206",
+            "artist": "dexter in the newsagent",
+            "name": "Special",
             "sources": [
                 {
-                    "name": "LA Times",
-                    "rank": 5,
-                    "quote": "'80s-pop cosplay so convincing that folks in 2025 forgot to make it a real hit"
-                },
-                {
-                    "name": "Quietus",
-                    "rank": 8,
-                    "quote": "Doja Cat channels Madonna and Vanity 6 for this sultry banger ... there just isn't really anyone else doing stuff like this right now and absolutely owning it."
-                }
-            ],
-            "list_count": 2,
-            "media": {
-                "youtube": {
-                    "music_id": "VmYbegvVfHE",
-                    "video_id": "lv1MwS56aCo"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/jealous-type/1834042903?i=1834042905"
-                },
-                "spotify": {
-                    "id": "03JZr55j9bIj1d2RQJ7Yq9"
-                }
-            },
-            "genres": [
-                "Pop"
-            ]
-        },
-        {
-            "id": "QZS7J2542546",
-            "artist": "MOLIY, Silent Addy, Skillibeng, & Shenseea",
-            "name": "Shake It To The Max (FLY) - Remix",
-            "sources": [
-                {
-                    "name": "Complex",
-                    "rank": 15,
-                    "quote": "one of the funnest, sweatiest dancefloor anthems of the year"
+                    "name": "AP",
+                    "uses_shadow_rank": true,
+                    "quote": "catchy and effervescent, like a vintage R&B cut but undeniably contemporary in its slow, romantic production"
                 },
                 {
                     "name": "NYT (Caramanica)",
-                    "rank": 16,
-                    "quote": "A global dancehall anthem that bridged Africa, the Caribbean and the United States"
+                    "rank": 7,
+                    "quote": "a delightful, patient, encouraging and nourishing whisper of a love song"
                 },
                 {
-                    "name": "Billboard Staff",
-                    "rank": 17,
-                    "quote": "an absolute banger that should've been nominated for a Grammy"
+                    "name": "FADER",
+                    "rank": 37,
+                    "quote": "Heartbreak here sounds both resigned and hopeful"
                 },
                 {
-                    "name": "Rolling Stone",
-                    "rank": 52,
-                    "quote": "melds classic dancehall vibes with modern instrumentation"
+                    "name": "Paste",
+                    "rank": 56,
+                    "quote": "dexter sings with such conviction that all you can do is bask in the beauty"
                 },
                 {
                     "name": "Pitchfork",
-                    "rank": 72,
-                    "quote": "a party honeypot, but what makes it so unforgettable is the way MOLIY sends the request up from the floor knowing she's not about to take any bullshit"
+                    "rank": 66,
+                    "quote": "full of grace and fully imagined, as if it had always been with us"
                 }
             ],
             "list_count": 5,
             "media": {
                 "youtube": {
-                    "music_id": "EVwh5pJj5KY",
-                    "video_id": "UjBhbMMgLzc"
+                    "music_id": "BvM3LQtvYDU",
+                    "video_id": "6vLZjyKuWEY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shake-it-to-the-max-fly-remix/1795039318?i=1795039319"
+                    "url": "https://music.apple.com/us/album/special/1818861416?i=1818861424"
                 },
                 "spotify": {
-                    "id": "0QCIpQV3twfqo9kh0t8Zza"
+                    "id": "7HWDQfrQvnAXp5Xk29xqh7"
                 }
             },
-            "genres": [
-                "Afrobeats",
-                "African"
-            ]
+            "genres": "Lo-Fi Indie"
         },
         {
-            "id": "USSM12504044",
-            "artist": "ROSAL\u00cdA, Estrella Morente, & S\u00edlvia P\u00e9rez Cruz",
-            "name": "La Rumba Del Perd\u00f3n",
+            "id": "USUG12506170",
+            "artist": "Chappell Roan",
+            "name": "The Subway",
             "sources": [
                 {
-                    "name": "Vulture",
+                    "name": "EW",
+                    "rank": 2,
+                    "quote": "the vivid imagery in their dream-pop stunner \"The Subway\" is a big reason why it's so relatably, palpably devastating"
+                },
+                {
+                    "name": "USA Today",
+                    "rank": 2,
+                    "quote": "a throwback to the '90s jangle-pop of The Cranberries and The Sundays ... Roan's voice aches with heartbreak"
+                },
+                {
+                    "name": "LA Times",
                     "rank": 3,
-                    "quote": "coming to grips with betrayal amid the gravitas of a rumba flamenca tune"
-                },
-                {
-                    "name": "LA Times",
-                    "rank": 8,
-                    "quote": "[A] woman possessed of celestial talents fights it out with the god who abandoned her"
-                }
-            ],
-            "list_count": 2,
-            "media": {
-                "youtube": {
-                    "music_id": "whWGBVowiHE",
-                    "video_id": "aobwPVZfuSQ"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/la-rumba-del-perd%C3%B3n/1848167516?i=1848167785"
-                },
-                "spotify": {
-                    "id": "7o76sIawH9bRWsltcWfQfd"
-                }
-            },
-            "genres": [
-                "Rock y Alternativo",
-                "Latin"
-            ]
-        },
-        {
-            "id": "USWB12502453",
-            "artist": "sombr",
-            "name": "12 to 12",
-            "sources": [
-                {
-                    "name": "Buzzfeed",
-                    "rank": 12,
-                    "quote": "\"12 to 12\" has a catchy '80s-inspired vibe, and those opening synths and vocal effects grab you from the very first seconds"
-                },
-                {
-                    "name": "LA Times",
-                    "rank": 23,
-                    "quote": "The zoomer wedding dance-floor anthem of 2035."
-                },
-                {
-                    "name": "ELLE",
-                    "uses_shadow_rank": true,
-                    "quote": "Sombr's 2010s alt-rock sound hits close to home"
-                },
-                {
-                    "name": "Variety",
-                    "uses_shadow_rank": true,
-                    "quote": "a swaggering pop song that packs all of the punch it promises"
-                },
-                {
-                    "name": "Billboard Staff",
-                    "rank": 42,
-                    "quote": "delivered one of the sleekest disco workouts of the year"
-                },
-                {
-                    "name": "NME",
-                    "rank": 47,
-                    "quote": "has a penchant for putting melancholic heartbreak to a funky melody and making it sound like an intoxicatingly good time"
-                },
-                {
-                    "name": "NPR Top 125",
-                    "uses_shadow_rank": true,
-                    "quote": "an undeniable '80s FM urgency ... The adrenaline rush of that driving groove and dramatic piano renders the rest of the track inconsequential"
-                }
-            ],
-            "list_count": 7,
-            "media": {
-                "youtube": {
-                    "music_id": "Lylp6w7LpHc",
-                    "video_id": "cZgUiR31m-Y"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/12-to-12/1828036634?i=1828036635"
-                },
-                "spotify": {
-                    "id": "05od2qm2MTSKCHxy1GBp5W"
-                }
-            },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
-        },
-        {
-            "id": "QM4TW2517490",
-            "artist": "Little Simz, Obongjayar, & Moonchild Sanelly",
-            "name": "Flood",
-            "sources": [
-                {
-                    "name": "Consequence",
-                    "rank": 18,
-                    "quote": "The UK rapper addresses betrayal with a haunting cadence and thunderous drums, taking no prisoners as she offers up hard-earned clarity and advice."
+                    "quote": "The vocal performance of the year."
                 },
                 {
                     "name": "Guardian",
-                    "rank": 20,
-                    "quote": "she lays out her six-point plan for greatness with koans of wisdom such as: \"Never eat with the hyenas / 'Cause they will look at you as bones.\""
+                    "rank": 3,
+                    "quote": "a lovelorn Celtic pop epic in thrall to the Cranberries ... reprising those torchbearers' snarling, choral rage"
                 },
                 {
-                    "name": "ELLE",
+                    "name": "Independent",
                     "uses_shadow_rank": true,
-                    "quote": "a master class in storytelling, showing a profound confidence from the rapper"
-                }
-            ],
-            "list_count": 3,
-            "media": {
-                "youtube": {
-                    "music_id": "FEORaPiNF6g",
-                    "video_id": "GvrNPiz7rHw"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/flood-feat-obongjayar-moonchild-sanelly/1794880972?i=1794880975"
-                },
-                "spotify": {
-                    "id": "3m9g8ua3M51JvqmS8rh6bS"
-                }
-            },
-            "genres": [
-                "Hip-Hop",
-                "Hip-Hop/Rap"
-            ]
-        },
-        {
-            "id": "QMB622500153",
-            "artist": "Hayley Williams",
-            "name": "True Believer",
-            "sources": [
-                {
-                    "name": "NME",
-                    "rank": 6,
-                    "quote": "makes an especially bold statement on 'True Believer' ... slicing deep into the historic rot that lies at the heart of her home"
-                },
-                {
-                    "name": "NPR Top 25",
-                    "uses_shadow_rank": true,
-                    "quote": "weeps and seethes for Nashville, a city built on religious systems that still justify colonization and racism"
-                },
-                {
-                    "name": "Consequence",
-                    "rank": 14,
-                    "quote": "she pours out her criticism like it's honeyed holy water over a false idol"
-                },
-                {
-                    "name": "Variety",
-                    "uses_shadow_rank": true,
-                    "quote": "makes for good, smart-mouthed pop at a time when most musicians are content to avoid the divisive elephants in the room"
-                }
-            ],
-            "list_count": 4,
-            "media": {
-                "youtube": {
-                    "music_id": "ZRH5vhscJZY",
-                    "video_id": "a5Uy5vDXhKI"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/true-believer/1850011909?i=1850012209"
-                },
-                "spotify": {
-                    "id": "4cSeIOmk8tffkGPYavEp57"
-                }
-            },
-            "genres": [
-                "Alternative"
-            ]
-        },
-        {
-            "id": "GBBKS2500056",
-            "artist": "Nourished by Time",
-            "name": "9 2 5",
-            "sources": [
-                {
-                    "name": "Quietus",
-                    "rank": 14,
-                    "quote": "an ode to the necessity of keeping the dream alive ... stands as the glistening centrepiece to Nourished By Time's superb second album"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 22,
-                    "quote": "makes the Sisyphean feat of a working-class artist sound like a scrappier version of an '80s boogie anthem for the nightclub"
-                },
-                {
-                    "name": "NME",
-                    "rank": 31,
-                    "quote": "he refuses to \"let the dreamer die\""
-                }
-            ],
-            "list_count": 3,
-            "media": {
-                "youtube": {
-                    "music_id": "ZJfqx_rxOTc",
-                    "video_id": "NEEv8DuqQSY"
-                },
-                "spotify": {
-                    "id": "6IzuJx4beJwcP9ImbZsKYd"
-                }
-            }
-        },
-        {
-            "id": "USA2P2520537",
-            "artist": "Ryan Davis & the Roadhouse Band",
-            "name": "New Threats From The Soul",
-            "sources": [
-                {
-                    "name": "Paste",
-                    "rank": 2,
-                    "quote": "the loudmouth tempo of Jerry Jeff Walker, the literary devastation of David Berman, and the oddball charm of a John Prine verse and blends them all into a potent, drunken recital of strangeness"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 5,
-                    "quote": "for as kaleidoscopic as the music can be, most listeners will come away just thinking about the lyrics, so full of humor and personality"
-                },
-                {
-                    "name": "Rolling Stone",
-                    "rank": 11,
-                    "quote": "distilling all that's complex and confounding about life into clarifying gems"
-                },
-                {
-                    "name": "Rough Trade",
-                    "uses_shadow_rank": true,
-                    "quote": "an album just comes right out of nowhere and knocks you out"
-                }
-            ],
-            "list_count": 4,
-            "media": {
-                "youtube": {
-                    "music_id": "t_GCZgqElQY",
-                    "video_id": "TuvUY9adrQ8"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/new-threats-from-the-soul/1826129223?i=1826129225"
-                },
-                "spotify": {
-                    "id": "1IXWSLygPDS5LQDQZH0NAz"
-                }
-            },
-            "genres": [
-                "Indie Rock",
-                "Alternative"
-            ]
-        },
-        {
-            "id": "USJ5G2542804",
-            "artist": "Wednesday",
-            "name": "Elderberry Wine",
-            "sources": [
-                {
-                    "name": "Slant",
-                    "rank": 5,
-                    "quote": "exudes such pleasant vibes ... it's actually a bittersweet breakup song"
+                    "quote": "\"The Subway\" is an open-hearted, grandiose slice of big-city yearning ... It sounds a little like something the late Dolores O'Riordan could have made, which only adds to its sublime melancholy."
                 },
                 {
                     "name": "AP",
                     "uses_shadow_rank": true,
-                    "quote": "a lovely, fermented rumination on a relationship gone sour, stuffed with poetic wisdom"
+                    "quote": "slow-burn dream-pop with Roan demonstrating her chameleonic properties by channeling both the Cranberries' Dolores O'Riordan and Alanis Morissette's yodel"
                 },
                 {
-                    "name": "Guardian",
-                    "rank": 18,
-                    "quote": "beneath all the twang and sway lay a fairly devastating account of the distance elapsed between two people"
-                },
-                {
-                    "name": "FADER",
-                    "rank": 27,
-                    "quote": "jam-packed with metaphors, imagery, and turns of phrase that it's practically a novel in miniature"
+                    "name": "Billboard Staff",
+                    "rank": 8,
+                    "quote": "utterly resplendent"
                 },
                 {
                     "name": "Rolling Stone",
-                    "rank": 47,
-                    "quote": "a lovely country-rock tune, steeped in pedal steel and patient jangle"
+                    "rank": 10,
+                    "quote": "this delicious heartbreaker ... the most emotionally devastating song about standing on a subway platform"
+                },
+                {
+                    "name": "Stereogum",
+                    "rank": 11,
+                    "quote": "a lovely, anthemic coda ... It's melancholy but somehow at peace, and totally sublime"
+                },
+                {
+                    "name": "Slant",
+                    "rank": 13,
+                    "quote": "A midtempo dream-pop ballad\u2014replete with crisp, teary-eyed guitars\u2014that finds Chappell Roan achingly pining for the one that got away"
+                },
+                {
+                    "name": "Crack",
+                    "rank": 17,
+                    "quote": "a moment of pure cathartic release"
                 },
                 {
                     "name": "Consequence",
-                    "rank": 106,
-                    "quote": "a tune as sweet as its namesake"
+                    "rank": 24,
+                    "quote": "offers a remarkable glimmer of Roan's cross-genre potential"
+                },
+                {
+                    "name": "ELLE",
+                    "uses_shadow_rank": true,
+                    "quote": "a dreamy '90s pop-rock feel, reminiscent of The Cranberries"
+                },
+                {
+                    "name": "Pitchfork",
+                    "rank": 31,
+                    "quote": "She's haunted by signs of her ex ... the flash of green hair and a beauty mark on a stranger that makes her heart stop"
+                },
+                {
+                    "name": "Rough Trade",
+                    "uses_shadow_rank": true,
+                    "quote": "paints such a devastatingly clear picture of lost love"
+                },
+                {
+                    "name": "NME",
+                    "rank": 35,
+                    "quote": "[she] lets completely loose ... the passionate, gut-wrenching two-minute outro"
+                }
+            ],
+            "list_count": 16,
+            "media": {
+                "youtube": {
+                    "music_id": "Qam5A9lG-wc",
+                    "video_id": "woLfAvD5iXI"
+                },
+                "apple": {
+                    "url": "https://music.apple.com/us/album/the-subway/1828261054?i=1828261475"
+                },
+                "spotify": {
+                    "id": "2SsY5k7UWFqgye3PUMG3Oq"
+                }
+            },
+            "genres": "Pop"
+        },
+        {
+            "id": "USJ5G2542802",
+            "artist": "Wednesday",
+            "name": "Townies",
+            "sources": [
+                {
+                    "name": "Stereogum",
+                    "rank": 1,
+                    "quote": "a master of writing grimy, evocative scenes of troubled youth that are daringly specific"
+                },
+                {
+                    "name": "Pitchfork",
+                    "rank": 7
+                },
+                {
+                    "name": "Consequence",
+                    "rank": 9,
+                    "quote": "the ultimate Wednesday song ... offers up one of the best examples of their countrygaze stylings"
+                },
+                {
+                    "name": "NPR Top 25",
+                    "uses_shadow_rank": true,
+                    "quote": "catchy, country-influenced storytelling and the rock-star ability to stretch the word \"died\" into nine syllables"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 21,
+                    "quote": "A mature and masterful missive from one of our greatest working songwriters"
+                },
+                {
+                    "name": "NME",
+                    "rank": 42,
+                    "quote": "excavating the pains of the past helps with closure"
                 }
             ],
             "list_count": 6,
             "media": {
                 "youtube": {
-                    "music_id": "CAoz3ykn2t4",
-                    "video_id": "uE0waEdE2Pw"
+                    "music_id": "mHEiyObNciA",
+                    "video_id": "E8cKoQqdtwA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/elderberry-wine/1809401153?i=1809401163"
+                    "url": "https://music.apple.com/us/album/townies/1807870796?i=1807870800"
                 },
                 "spotify": {
-                    "id": "00lSB9CSyOcsxKVtbPbniL"
+                    "id": "2deA4WXDrTa7jAZuaIAeqo"
+                },
+                "bandcamp": {
+                    "url": "https://wednesdayband.bandcamp.com/track/townies"
                 }
             },
-            "genres": [
-                "Alternative"
-            ]
+            "genres": "Alt Country"
+        },
+        {
+            "id": "QZVEM2532603",
+            "artist": "zayALLCAPS",
+            "name": "MTV's Pimp My Ride",
+            "sources": [
+                {
+                    "name": "FADER",
+                    "rank": 28,
+                    "quote": "blurs the line between meet-cute, seduction, and homage to the titular 2000s reality TV staple"
+                },
+                {
+                    "name": "Consequence",
+                    "rank": 37,
+                    "quote": "zayALLCAPS knows how to make even the most throwback sounds feel current and unique"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 47,
+                    "quote": "proves that nostalgia isn't the artistically bankrupt strategy many make it out to be"
+                },
+                {
+                    "name": "Pitchfork",
+                    "rank": 50,
+                    "quote": "an R&B jam with the same zaniness that made the show so popular"
+                }
+            ],
+            "list_count": 4,
+            "media": {
+                "youtube": {
+                    "music_id": "S4OzEth_euE",
+                    "video_id": "S4OzEth_euE"
+                },
+                "apple": {
+                    "url": "https://music.apple.com/us/album/mtvs-pimp-my-ride/1802142712?i=1802142713"
+                },
+                "spotify": {
+                    "id": "6sRu3Bf5hxIRCQ8XGfYv1c"
+                }
+            },
+            "genres": "R&B/Soul"
+        },
+        {
+            "id": "US2U62539801",
+            "artist": "feeble little horse",
+            "name": "This Is Real",
+            "sources": [
+                {
+                    "name": "AP",
+                    "uses_shadow_rank": true,
+                    "quote": "pushes the envelope further, working in computerized, hyperpop-esque electronics ... one of their heaviest tracks to date"
+                },
+                {
+                    "name": "Stereogum",
+                    "rank": 45,
+                    "quote": "glitchy jangle riffs, overlapping twee-folk refrains\u2026 and the heaviest breakdown this year outside of metal"
+                },
+                {
+                    "name": "Quietus",
+                    "rank": 47
+                },
+                {
+                    "name": "Rolling Stone",
+                    "rank": 82,
+                    "quote": "collide bedroom pop, noise pop, and hyper pop ... turns into bubbly electro cuteness, then runs into a wall of power-drone grind, then becomes a Nineties-style grunge-punk tantrum"
+                }
+            ],
+            "list_count": 4,
+            "media": {
+                "youtube": {
+                    "music_id": "4tT4thtTees",
+                    "video_id": "ZZ5ARgm--Ok"
+                },
+                "apple": {
+                    "url": "https://music.apple.com/us/album/this-is-real/1796181543?i=1796181548"
+                },
+                "spotify": {
+                    "id": "4LYXtoiuM9xEmxklVvQnLl"
+                },
+                "bandcamp": {
+                    "url": "https://feeblelittlehorse.bandcamp.com/track/this-is-real"
+                }
+            },
+            "genres": "Shoegaze"
+        },
+        {
+            "id": "QMFMF2447057",
+            "artist": "Bad Bunny",
+            "name": "BAILE INoLVIDABLE",
+            "sources": [
+                {
+                    "name": "LA Times",
+                    "rank": 1,
+                    "quote": "a six-minute ode to the island's roots and influence on the genre ... salsa has become cool once again"
+                },
+                {
+                    "name": "Rolling Stone",
+                    "rank": 4,
+                    "quote": "the album's most poignant facet is his take on salsa"
+                },
+                {
+                    "name": "EW",
+                    "rank": 4,
+                    "quote": "six minutes of pure, unbridled joy, a glorious and exultant tribute to salsa and the power of dance"
+                },
+                {
+                    "name": "Complex",
+                    "rank": 6,
+                    "quote": "a salsa track ... it features a twist ... lively salsa rhythms, layered with twinkling pianos, congas, timbales, and a brassy trumpet melody that could make anyone dance"
+                },
+                {
+                    "name": "NME",
+                    "rank": 10,
+                    "quote": "'Baile Inolvidable' is one of his most magnificent torch songs"
+                },
+                {
+                    "name": "NPR Top 25",
+                    "uses_shadow_rank": true,
+                    "quote": "The song comes alive in a complex expression of communal pain"
+                },
+                {
+                    "name": "ELLE",
+                    "uses_shadow_rank": true,
+                    "quote": "melancholy, but glows with warm instrumentation and harmonies"
+                },
+                {
+                    "name": "Slant",
+                    "rank": 27,
+                    "quote": "a spine-chilling collision of old and new ... turning the dance floor into a metaphor for life itself: as a party that must end"
+                }
+            ],
+            "list_count": 8,
+            "media": {
+                "youtube": {
+                    "music_id": "JseJETvMtHY",
+                    "video_id": "a1Femq4NPxs"
+                },
+                "apple": {
+                    "url": "https://music.apple.com/us/album/baile-inolvidable/1787022393?i=1787022842"
+                },
+                "spotify": {
+                    "id": "2lTm559tuIvatlT1u0JYG2"
+                }
+            },
+            "genres": "Reggaeton"
+        },
+        {
+            "id": "GBBKS2500077",
+            "artist": "Jim Legxacy",
+            "name": "stick",
+            "sources": [
+                {
+                    "name": "Vulture",
+                    "rank": 4,
+                    "quote": "surveys tough times sweetly"
+                },
+                {
+                    "name": "FADER",
+                    "rank": 8,
+                    "quote": "inexplicably moving and seriously addictive"
+                },
+                {
+                    "name": "NPR Top 25",
+                    "uses_shadow_rank": true,
+                    "quote": "the ascendant U.K. rapper is an aerial dancer here, whirling between half-sung catch phrases on a ribbon of hummed chords"
+                }
+            ],
+            "list_count": 3,
+            "media": {
+                "youtube": {
+                    "music_id": "YrVJE_6Hg6c",
+                    "video_id": "qfDIhj8UIfc"
+                },
+                "spotify": {
+                    "id": "03zypUrD0e5vrFcmc80NJm"
+                }
+            }
+        },
+        {
+            "id": "GBBKS2500311",
+            "artist": "Jim Legxacy",
+            "name": "'06 wayne rooney",
+            "sources": [
+                {
+                    "name": "GvsB",
+                    "rank": 9
+                },
+                {
+                    "name": "Quietus",
+                    "rank": 19,
+                    "quote": "a painful and refreshingly open insight into the effects of the chaos that life throws at us"
+                },
+                {
+                    "name": "Stereogum",
+                    "rank": 30,
+                    "quote": "Converting inner-city turmoil into pillowy singalong hooks is something that comes natural for Jim Legxacy"
+                },
+                {
+                    "name": "Rough Trade",
+                    "uses_shadow_rank": true,
+                    "quote": "the perfect example of Jim's power in evoking an era, producing nostalgia and reflecting on real life shit"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 59,
+                    "quote": "[A] poignant reminder that \"making it\" isn't always a salve for old wounds"
+                },
+                {
+                    "name": "Consequence",
+                    "rank": 191,
+                    "quote": "Channeling the spirit of mid-aughts landfill indie and a myriad of bangers from FIFA soundtracks"
+                }
+            ],
+            "list_count": 6,
+            "media": {
+                "youtube": {
+                    "music_id": "Yq8EXOJbsCE",
+                    "video_id": "RhjZgIk9oCs"
+                },
+                "spotify": {
+                    "id": "7p6LdEcYnSbw68yJDbUjxD"
+                }
+            }
+        },
+        {
+            "id": "GBLZC2400049",
+            "artist": "aya",
+            "name": "off to the ESSO",
+            "sources": [
+                {
+                    "name": "Quietus",
+                    "rank": 2,
+                    "quote": "nerve-jangling sound design, delirium tremens percussion skitter ... actually combine to produce one of the most life-affirming bangers of recent years"
+                },
+                {
+                    "name": "Stereogum",
+                    "rank": 13,
+                    "quote": "nauseating dubstep-meets-gabber ... [with] timbres [that] squelch and burst"
+                },
+                {
+                    "name": "Guardian",
+                    "rank": 14,
+                    "quote": "conjures the skull-clattering experience of being too drunk on public transport at an indeterminate morning hour"
+                },
+                {
+                    "name": "Pitchfork",
+                    "rank": 17,
+                    "quote": "a terrifying, upsetting portrait of drug addiction"
+                },
+                {
+                    "name": "Dazed",
+                    "rank": 17,
+                    "quote": "bundles all of this up in a frantic three-and-a-half minutes, beginning with a thumping bass ... culminating with a ruckus of aggressive synths"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 45,
+                    "quote": "You can feel every buzz, screech, and smack in your bones, taking over your whole being like a persistent parasite"
+                }
+            ],
+            "list_count": 6,
+            "media": {
+                "youtube": {
+                    "music_id": "yBMSzoovWbw",
+                    "video_id": "-vgDl8Asle0"
+                },
+                "apple": {
+                    "url": "https://music.apple.com/us/album/off-to-the-esso/1791674346?i=1791674348"
+                },
+                "spotify": {
+                    "id": "4BsGxMMDdcWQzrUTGXqlAE"
+                },
+                "bandcamp": {
+                    "url": "https://aya-yco.bandcamp.com/track/off-to-the-esso"
+                }
+            },
+            "genres": "Experimental"
         }
     ]
 }

--- a/script.js
+++ b/script.js
@@ -328,6 +328,7 @@ function render() {
                             <hgroup>
                                 <h3>${escapeHtml(song.name)}</h3>
                                 <h4>${escapeHtml(song.artist)}</h4>
+                                ${song.genres ? `<h5 class="song-genres">${escapeHtml(song.genres)}</h5>` : ''}
                             </hgroup>
                             <a href="#" onclick="showStats(${idx}); return false;" aria-label="View ranking details">ⓘ</a>
                         </header>


### PR DESCRIPTION
## Summary
Adds genre information to song cards, displayed below the artist name.

## Changes
- Add `genres` field to data schema and populate in data.json
- Display genres as h5 element below artist name in song cards
- Style with Pico h5 color and 0.8rem font size for subtle appearance
- Use semantic heading hierarchy (h3 → h4 → h5)
- Remove margin-bottom from h4 for better spacing between artist and genre
- Add `.song-genres` CSS class with specific selector to override Pico defaults
- Update sample_data.json with genre examples

## Screenshots
Genres appear in a small, muted font below the artist name, maintaining proper visual hierarchy.

Fixes #11