### PR TITLE
Switch to using geo.music.apple.com for Apple Music links

### DIFF
--- a/data.json
+++ b/data.json
@@ -348,7 +348,7 @@
                     "video_id": "woLfAvD5iXI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-subway/1828261054?i=1828261475"
+                    "url": "https://geo.music.apple.com/us/album/the-subway/1828261054?i=1828261475"
                 },
                 "spotify": {
                     "id": "2SsY5k7UWFqgye3PUMG3Oq"
@@ -522,7 +522,7 @@
                     "video_id": "vBynw9Isr28"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/abracadabra/1837310866?i=1837310871"
+                    "url": "https://geo.music.apple.com/us/album/abracadabra/1837310866?i=1837310871"
                 },
                 "spotify": {
                     "id": "2LHNTC9QZxsL3nWpt8iaSR"
@@ -602,7 +602,7 @@
                     "video_id": "oIv_Y2RPQ_A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/man-i-need/1817609404?i=1817609509"
+                    "url": "https://geo.music.apple.com/us/album/man-i-need/1817609404?i=1817609509"
                 },
                 "spotify": {
                     "id": "1qbmS6ep2hbBRaEZFpn7BX"
@@ -673,7 +673,7 @@
                     "video_id": "KFMYx1TibeQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/folded/1859622026?i=1859622044"
+                    "url": "https://geo.music.apple.com/us/album/folded/1859622026?i=1859622044"
                 },
                 "spotify": {
                     "id": "0bxPRWprUVpQK0UFcddkrA"
@@ -739,7 +739,7 @@
                     "video_id": "yebNIHKAC4A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/golden/1824324832?i=1824324836"
+                    "url": "https://geo.music.apple.com/us/album/golden/1824324832?i=1824324836"
                 },
                 "spotify": {
                     "id": "1CPZ5BxNNd0n0nF4Orb9JS"
@@ -805,7 +805,7 @@
                     "video_id": "htQBS2Ikz6c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/berghain/1848167516?i=1848167528"
+                    "url": "https://geo.music.apple.com/us/album/berghain/1848167516?i=1848167528"
                 },
                 "spotify": {
                     "id": "2T8yuUKl1nhmtaIocqWo4i"
@@ -866,7 +866,7 @@
                     "video_id": "a1Femq4NPxs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/baile-inolvidable/1787022393?i=1787022842"
+                    "url": "https://geo.music.apple.com/us/album/baile-inolvidable/1787022393?i=1787022842"
                 },
                 "spotify": {
                     "id": "2lTm559tuIvatlT1u0JYG2"
@@ -931,7 +931,7 @@
                     "video_id": "Tgw9cFdCPxU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/blade-bird/1790530990?i=1790530991"
+                    "url": "https://geo.music.apple.com/us/album/blade-bird/1790530990?i=1790530991"
                 },
                 "spotify": {
                     "id": "45LwOlqL3HOEQkPjjHpu7U"
@@ -1005,7 +1005,7 @@
                     "video_id": "aSugSGCC12I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/body/1864605315?i=1864605316"
+                    "url": "https://geo.music.apple.com/us/album/body/1864605315?i=1864605316"
                 },
                 "spotify": {
                     "id": "42UBPzRMh5yyz0EDPr6fr1"
@@ -1071,7 +1071,7 @@
                     "video_id": "XdFpzaM07i0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/headphones-on/1808473781?i=1808473785"
+                    "url": "https://geo.music.apple.com/us/album/headphones-on/1808473781?i=1808473785"
                 },
                 "spotify": {
                     "id": "3H6xZgwRZx8McVUJzmMxWe"
@@ -1141,7 +1141,7 @@
                     "video_id": "rK5TyISxZ_M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/where-is-my-husband/1838737596?i=1838737598"
+                    "url": "https://geo.music.apple.com/us/album/where-is-my-husband/1838737596?i=1838737598"
                 },
                 "spotify": {
                     "id": "55lijDD6OAjLFFUHU9tcDm"
@@ -1212,7 +1212,7 @@
                     "video_id": "AJGS18kol_U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/yamaha/1836958810?i=1836960422"
+                    "url": "https://geo.music.apple.com/us/album/yamaha/1836958810?i=1836960422"
                 },
                 "spotify": {
                     "id": "6qR5YGunNSASaabs4kJB9V"
@@ -1278,7 +1278,7 @@
                     "video_id": "dOI_QTmK8Ks"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/relationships/1809849957?i=1809849960"
+                    "url": "https://geo.music.apple.com/us/album/relationships/1809849957?i=1809849960"
                 },
                 "spotify": {
                     "id": "1FlDLGaTsr9HH1zfJiq6is"
@@ -1333,7 +1333,7 @@
                     "video_id": "LzEzE3cpuvg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/you-got-time-and-i-got-money/1802661282?i=1802661558"
+                    "url": "https://geo.music.apple.com/us/album/you-got-time-and-i-got-money/1802661282?i=1802661558"
                 },
                 "spotify": {
                     "id": "4YDl2Oxc1mVRnZsZAbNzI0"
@@ -1399,7 +1399,7 @@
                     "video_id": "7InTkBxPtK4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sports-car/1853104433?i=1853104685"
+                    "url": "https://geo.music.apple.com/us/album/sports-car/1853104433?i=1853104685"
                 },
                 "spotify": {
                     "id": "2zOmS55knKWSgScYPTNmGQ"
@@ -1450,7 +1450,7 @@
                     "video_id": "Phh3oVCtzBg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/taxes/1818548779?i=1818549167"
+                    "url": "https://geo.music.apple.com/us/album/taxes/1818548779?i=1818549167"
                 },
                 "spotify": {
                     "id": "5cbDTZG8lBJqVVa2zqROPI"
@@ -1503,7 +1503,7 @@
                     "video_id": "E8cKoQqdtwA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/townies/1807870796?i=1807870800"
+                    "url": "https://geo.music.apple.com/us/album/townies/1807870796?i=1807870800"
                 },
                 "spotify": {
                     "id": "2deA4WXDrTa7jAZuaIAeqo"
@@ -1567,7 +1567,7 @@
                     "video_id": "xqRNYtiAAP8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/p-y-palace/1846342052?i=1846342309"
+                    "url": "https://geo.music.apple.com/us/album/p-y-palace/1846342052?i=1846342309"
                 },
                 "spotify": {
                     "id": "73vfMXcXa6iY1E3lpf2fZO"
@@ -1675,7 +1675,7 @@
                     "video_id": "kt0Z9RZkg-4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/afterlife/1815825254?i=1815825509"
+                    "url": "https://geo.music.apple.com/us/album/afterlife/1815825254?i=1815825509"
                 },
                 "spotify": {
                     "id": "0yYQbFuqvXyZc46e2QEqI7"
@@ -1729,7 +1729,7 @@
                     "video_id": "NgeeXzljuPY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/s-m-o/1821073090?i=1821073398"
+                    "url": "https://geo.music.apple.com/us/album/s-m-o/1821073090?i=1821073398"
                 },
                 "spotify": {
                     "id": "7iYrk5G9jTqY5oG8k7Lj0B"
@@ -1775,7 +1775,7 @@
                     "video_id": "fXivMSJm_kA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/yukon/1839605744?i=1839605914"
+                    "url": "https://geo.music.apple.com/us/album/yukon/1839605744?i=1839605914"
                 },
                 "spotify": {
                     "id": "29iva9idM6rFCPUlu7Rhxl"
@@ -1830,7 +1830,7 @@
                     "video_id": "v9T_MGfzq7I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dtmf/1787022393?i=1787023936"
+                    "url": "https://geo.music.apple.com/us/album/dtmf/1787022393?i=1787023936"
                 },
                 "spotify": {
                     "id": "3sK8wGT43QFpWrvNQsrQya"
@@ -1881,7 +1881,7 @@
                     "video_id": "-vgDl8Asle0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/off-to-the-esso/1791674346?i=1791674348"
+                    "url": "https://geo.music.apple.com/us/album/off-to-the-esso/1791674346?i=1791674348"
                 },
                 "spotify": {
                     "id": "4BsGxMMDdcWQzrUTGXqlAE"
@@ -1930,7 +1930,7 @@
                     "video_id": "UWyFj-TD9-M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nokia/1796127242?i=1796127375"
+                    "url": "https://geo.music.apple.com/us/album/nokia/1796127242?i=1796127375"
                 },
                 "spotify": {
                     "id": "2u9S9JJ6hTZS3Vf22HOZKg"
@@ -1971,7 +1971,7 @@
                     "video_id": "K6QjQeKfmUs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lv-sandals/1821499702?i=1821499704"
+                    "url": "https://geo.music.apple.com/us/album/lv-sandals/1821499702?i=1821499704"
                 },
                 "spotify": {
                     "id": "5uz5v1hRZLjNGatcPtOWUv"
@@ -2082,7 +2082,7 @@
                     "video_id": "uE0waEdE2Pw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/elderberry-wine/1809401153?i=1809401163"
+                    "url": "https://geo.music.apple.com/us/album/elderberry-wine/1809401153?i=1809401163"
                 },
                 "spotify": {
                     "id": "00lSB9CSyOcsxKVtbPbniL"
@@ -2127,7 +2127,7 @@
                     "video_id": "2chmQiR8R10"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/play/1807351546?i=1807351547"
+                    "url": "https://geo.music.apple.com/us/album/play/1807351546?i=1807351547"
                 },
                 "spotify": {
                     "id": "4EbKAHT7I23BeXQFJ041Ls"
@@ -2181,7 +2181,7 @@
                     "video_id": "Xee_2r-5L2U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/love-takes-miles/1766984761?i=1766985021"
+                    "url": "https://geo.music.apple.com/us/album/love-takes-miles/1766984761?i=1766985021"
                 },
                 "spotify": {
                     "id": "2zf1izCOz2F22PF27uhxRF"
@@ -2274,7 +2274,7 @@
                     "video_id": "KU5V5WZVcVE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nuevayol/1787022393?i=1787022572"
+                    "url": "https://geo.music.apple.com/us/album/nuevayol/1787022393?i=1787022572"
                 },
                 "spotify": {
                     "id": "5TFD2bmFKGhoCRbX61nXY5"
@@ -2315,7 +2315,7 @@
                     "video_id": "TuvUY9adrQ8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/new-threats-from-the-soul/1826129223?i=1826129225"
+                    "url": "https://geo.music.apple.com/us/album/new-threats-from-the-soul/1826129223?i=1826129225"
                 },
                 "spotify": {
                     "id": "1IXWSLygPDS5LQDQZH0NAz"
@@ -2361,7 +2361,7 @@
                     "video_id": "hLOheGDwD_0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/choosin-texas/1844932149?i=1844932150"
+                    "url": "https://geo.music.apple.com/us/album/choosin-texas/1844932149?i=1844932150"
                 },
                 "spotify": {
                     "id": "65DbTqJKhbwqYbZ1Okr0rc"
@@ -2407,7 +2407,7 @@
                     "video_id": "TkwZ2uQu2hE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/fame-is-a-gun/1809015416?i=1809015879"
+                    "url": "https://geo.music.apple.com/us/album/fame-is-a-gun/1809015416?i=1809015879"
                 },
                 "spotify": {
                     "id": "7B3BwNecBhKvNwSMOOl7Gk"
@@ -2453,7 +2453,7 @@
                     "video_id": "QyvREl7epGY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/daisies/1839605744?i=1839605912"
+                    "url": "https://geo.music.apple.com/us/album/daisies/1839605744?i=1839605912"
                 },
                 "spotify": {
                     "id": "5BZsQlgw21vDOAjoqkNgKb"
@@ -2499,7 +2499,7 @@
                     "video_id": "Vn4mni6GJD0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/plastic-box/1813142774?i=1813143294"
+                    "url": "https://geo.music.apple.com/us/album/plastic-box/1813142774?i=1813143294"
                 },
                 "spotify": {
                     "id": "5v5ESV1s4Y964nDJdxb2s4"
@@ -2540,7 +2540,7 @@
                     "video_id": "HfWLgELllZs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/luther/1781270319?i=1781270323"
+                    "url": "https://geo.music.apple.com/us/album/luther/1781270319?i=1781270323"
                 },
                 "spotify": {
                     "id": "2CGNAOSuO1MEFCbBRgUzjd"
@@ -2576,7 +2576,7 @@
                     "video_id": "R2-yomhYAj4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gnarly/1809854729?i=1809854730"
+                    "url": "https://geo.music.apple.com/us/album/gnarly/1809854729?i=1809854730"
                 },
                 "spotify": {
                     "id": "1j15Ar0qGDzIR0v3CQv3JL"
@@ -2622,7 +2622,7 @@
                     "video_id": "37ptdYkJ1d0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cinderella/1793740725?i=1793740849"
+                    "url": "https://geo.music.apple.com/us/album/cinderella/1793740725?i=1793740849"
                 },
                 "spotify": {
                     "id": "37Dsnkoxh3zFRcEwZAOIBg"
@@ -2700,7 +2700,7 @@
                     "video_id": "iUZyn_w6Y1Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/take-me-thru-dere/1851128496?i=1851128927"
+                    "url": "https://geo.music.apple.com/us/album/take-me-thru-dere/1851128496?i=1851128927"
                 },
                 "spotify": {
                     "id": "2GFawZaMjG8QLxiR4OD3db"
@@ -2746,7 +2746,7 @@
                     "video_id": "UjBhbMMgLzc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shake-it-to-the-max-fly-remix/1795039318?i=1795039319"
+                    "url": "https://geo.music.apple.com/us/album/shake-it-to-the-max-fly-remix/1795039318?i=1795039319"
                 },
                 "spotify": {
                     "id": "0QCIpQV3twfqo9kh0t8Zza"
@@ -2792,7 +2792,7 @@
                     "video_id": "J-jCnsJEAFs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/whim-whamiee/1825736801?i=1825737197"
+                    "url": "https://geo.music.apple.com/us/album/whim-whamiee/1825736801?i=1825737197"
                 },
                 "spotify": {
                     "id": "4eULTkHVLAhn5J5DOSNbdP"
@@ -2874,7 +2874,7 @@
                     "video_id": "URlPXepBZdo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/so-be-it/1862672249?i=1862672270"
+                    "url": "https://geo.music.apple.com/us/album/so-be-it/1862672249?i=1862672270"
                 },
                 "spotify": {
                     "id": "0xaQ86cGRgcF8wwP1SkXsb"
@@ -2925,7 +2925,7 @@
                     "video_id": "uvY8fdgezLQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/midnight-sun/1817499239?i=1817499251"
+                    "url": "https://geo.music.apple.com/us/album/midnight-sun/1817499239?i=1817499251"
                 },
                 "spotify": {
                     "id": "7N1GSHGlLwXY3lN5gv3QLV"
@@ -2971,7 +2971,7 @@
                     "video_id": "6vLZjyKuWEY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/special/1818861416?i=1818861424"
+                    "url": "https://geo.music.apple.com/us/album/special/1818861416?i=1818861424"
                 },
                 "spotify": {
                     "id": "7HWDQfrQvnAXp5Xk29xqh7"
@@ -3017,7 +3017,7 @@
                     "video_id": "WG0mAzP165o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-want-you-fever/1789010624?i=1789010625"
+                    "url": "https://geo.music.apple.com/us/album/i-want-you-fever/1789010624?i=1789010625"
                 },
                 "spotify": {
                     "id": "4Ze7DFjyVa0smRqY2Fxcnz"
@@ -3071,7 +3071,7 @@
                     "video_id": "ye1_CSuv5NM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mangetout/1802918329?i=1802918493"
+                    "url": "https://geo.music.apple.com/us/album/mangetout/1802918329?i=1802918493"
                 },
                 "spotify": {
                     "id": "5UW4tA4j23YL6kDfRw3rWT"
@@ -3127,7 +3127,7 @@
                     "video_id": "cZgUiR31m-Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/12-to-12/1828036634?i=1828036635"
+                    "url": "https://geo.music.apple.com/us/album/12-to-12/1828036634?i=1828036635"
                 },
                 "spotify": {
                     "id": "05od2qm2MTSKCHxy1GBp5W"
@@ -3168,7 +3168,7 @@
                     "video_id": "a5Uy5vDXhKI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/true-believer/1850011909?i=1850012209"
+                    "url": "https://geo.music.apple.com/us/album/true-believer/1850011909?i=1850012209"
                 },
                 "spotify": {
                     "id": "4cSeIOmk8tffkGPYavEp57"
@@ -3255,7 +3255,7 @@
                     "video_id": "EUjUNCDPc70"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/take-a-sexy-picture-of-me/1802736479?i=1802736661"
+                    "url": "https://geo.music.apple.com/us/album/take-a-sexy-picture-of-me/1802736479?i=1802736661"
                 },
                 "spotify": {
                     "id": "0XWCzu4SUFz2jusWBPrDvU"
@@ -3311,7 +3311,7 @@
                     "video_id": "ljHdccyQbT4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sugar-on-my-tongue/1827715784?i=1827715792"
+                    "url": "https://geo.music.apple.com/us/album/sugar-on-my-tongue/1827715784?i=1827715792"
                 },
                 "spotify": {
                     "id": "6xV7Be6XEvkSnighmh2Tzj"
@@ -3347,7 +3347,7 @@
                     "video_id": "C217vygclrk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/like-weezy/1802175271?i=1802175748"
+                    "url": "https://geo.music.apple.com/us/album/like-weezy/1802175271?i=1802175748"
                 },
                 "spotify": {
                     "id": "4zK082ykqJzJGzC64NXjp1"
@@ -3383,7 +3383,7 @@
                     "video_id": "7BUI9S6PEiI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dancing-in-the-club-mj-lenderman-version/1798863394?i=1798863726"
+                    "url": "https://geo.music.apple.com/us/album/dancing-in-the-club-mj-lenderman-version/1798863394?i=1798863726"
                 },
                 "spotify": {
                     "id": "2aFkH4wK9nZbgtmlq411f2"
@@ -3419,7 +3419,7 @@
                     "video_id": "xPaSuWrBAQI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/reliquia/1848167516?i=1848167522"
+                    "url": "https://geo.music.apple.com/us/album/reliquia/1848167516?i=1848167522"
                 },
                 "spotify": {
                     "id": "4ORvXsPK9AJmDzm36BYcdy"
@@ -3455,7 +3455,7 @@
                     "video_id": "bptXEszZMuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/birds/1826568800?i=1826569145"
+                    "url": "https://geo.music.apple.com/us/album/birds/1826568800?i=1826569145"
                 },
                 "spotify": {
                     "id": "0k9JIBszlCqCa4SpXI353F"
@@ -3486,7 +3486,7 @@
                     "video_id": "aobwPVZfuSQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/la-rumba-del-perd%C3%B3n/1848167516?i=1848167785"
+                    "url": "https://geo.music.apple.com/us/album/la-rumba-del-perd%C3%B3n/1848167516?i=1848167785"
                 },
                 "spotify": {
                     "id": "7o76sIawH9bRWsltcWfQfd"
@@ -3526,7 +3526,7 @@
                     "video_id": "ecIH-4RbbOk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/chains-whips/1862672249?i=1862672261"
+                    "url": "https://geo.music.apple.com/us/album/chains-whips/1862672249?i=1862672261"
                 },
                 "spotify": {
                     "id": "3znSvEwBq09We4cxxmwlZM"
@@ -3567,7 +3567,7 @@
                     "video_id": "RjEqtsafnkA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/f-k-me-eyes/1818431571?i=1818431575"
+                    "url": "https://geo.music.apple.com/us/album/f-k-me-eyes/1818431571?i=1818431575"
                 },
                 "spotify": {
                     "id": "4Ozk6GESL4KkJ0C1yXgDLf"
@@ -3649,7 +3649,7 @@
                     "video_id": "xaW48sjI-JU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bodega-baddie/1852374241?i=1852374420"
+                    "url": "https://geo.music.apple.com/us/album/bodega-baddie/1852374241?i=1852374420"
                 },
                 "spotify": {
                     "id": "4JI9FH3KOYOushudtnZt0z"
@@ -3685,7 +3685,7 @@
                     "video_id": "Jx9h3iWudTU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/burning-blue/1837526620?i=1837526777"
+                    "url": "https://geo.music.apple.com/us/album/burning-blue/1837526620?i=1837526777"
                 },
                 "spotify": {
                     "id": "1WBD2KNkYu880G7ElAituh"
@@ -3758,7 +3758,7 @@
                     "video_id": "XoqyAWcedvM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shot-callin/1824363644?i=1824363817"
+                    "url": "https://geo.music.apple.com/us/album/shot-callin/1824363644?i=1824363817"
                 },
                 "spotify": {
                     "id": "4n4tC4qO2LeWQRM9Gbbtop"
@@ -3794,7 +3794,7 @@
                     "video_id": "XnygT6ANLzQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/doot-doot-6-7-bonus-track/1798833506?i=1798833782"
+                    "url": "https://geo.music.apple.com/us/album/doot-doot-6-7-bonus-track/1798833506?i=1798833782"
                 },
                 "spotify": {
                     "id": "18DEvCPCmzVpo2en9DeylA"
@@ -3882,7 +3882,7 @@
                     "video_id": "6Kjz89xYmS4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/catch-these-fists/1802918329?i=1802918484"
+                    "url": "https://geo.music.apple.com/us/album/catch-these-fists/1802918329?i=1802918484"
                 },
                 "spotify": {
                     "id": "5yz4ZfLeZ3VdqDM2l8wjjg"
@@ -3918,7 +3918,7 @@
                     "video_id": "vssRKoGhD9Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/girl-feels-good/1851537334?i=1851537336"
+                    "url": "https://geo.music.apple.com/us/album/girl-feels-good/1851537334?i=1851537336"
                 },
                 "spotify": {
                     "id": "536rHxlVFXGJBO2xWE7HsV"
@@ -3949,7 +3949,7 @@
                     "video_id": "lv1MwS56aCo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jealous-type/1834042903?i=1834042905"
+                    "url": "https://geo.music.apple.com/us/album/jealous-type/1834042903?i=1834042905"
                 },
                 "spotify": {
                     "id": "03JZr55j9bIj1d2RQJ7Yq9"
@@ -3985,7 +3985,7 @@
                     "video_id": "yTaz0TB9Zco"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-field-feat-the-durutti-column-tariq-al-sabir/1825903903?i=1825903910"
+                    "url": "https://geo.music.apple.com/us/album/the-field-feat-the-durutti-column-tariq-al-sabir/1825903903?i=1825903910"
                 },
                 "spotify": {
                     "id": "1XMBjGYUakFEjI4ZaISVt2"
@@ -4016,7 +4016,7 @@
                     "video_id": "4iSvoQNfrrk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/caramel/1800532611?i=1800533447"
+                    "url": "https://geo.music.apple.com/us/album/caramel/1800532611?i=1800533447"
                 },
                 "spotify": {
                     "id": "1QrbZhFYlViXd60g130vw1"
@@ -4052,7 +4052,7 @@
                     "video_id": "CXBFU97X61I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/end-of-the-world/1839062794?i=1839063067"
+                    "url": "https://geo.music.apple.com/us/album/end-of-the-world/1839062794?i=1839063067"
                 },
                 "spotify": {
                     "id": "5SxahezRlC0saXbCALfB7c"
@@ -4125,7 +4125,7 @@
                     "video_id": "3ctZ0MuCFuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/parachute/1850011909?i=1850012505"
+                    "url": "https://geo.music.apple.com/us/album/parachute/1850011909?i=1850012505"
                 },
                 "spotify": {
                     "id": "5iALdwbhnUHa8zGStA3h1J"
@@ -4161,7 +4161,7 @@
                     "video_id": "lF3QLdBTrS0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sex-life-feat-riko-dan/1800521450?i=1800521452"
+                    "url": "https://geo.music.apple.com/us/album/sex-life-feat-riko-dan/1800521450?i=1800521452"
                 },
                 "spotify": {
                     "id": "18cS2gM9O0jkVYCBuMsBLq"
@@ -4202,7 +4202,7 @@
                     "video_id": "riCP9x31Kuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/anxiety/1855650353?i=1855650674"
+                    "url": "https://geo.music.apple.com/us/album/anxiety/1855650353?i=1855650674"
                 },
                 "spotify": {
                     "id": "1musbempyJAw5gfSKZHXP9"
@@ -4238,7 +4238,7 @@
                     "video_id": "GvrNPiz7rHw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/flood-feat-obongjayar-moonchild-sanelly/1794880972?i=1794880975"
+                    "url": "https://geo.music.apple.com/us/album/flood-feat-obongjayar-moonchild-sanelly/1794880972?i=1794880975"
                 },
                 "spotify": {
                     "id": "3m9g8ua3M51JvqmS8rh6bS"
@@ -4279,7 +4279,7 @@
                     "video_id": "S4OzEth_euE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mtvs-pimp-my-ride/1802142712?i=1802142713"
+                    "url": "https://geo.music.apple.com/us/album/mtvs-pimp-my-ride/1802142712?i=1802142713"
                 },
                 "spotify": {
                     "id": "6sRu3Bf5hxIRCQ8XGfYv1c"
@@ -4342,7 +4342,7 @@
                     "video_id": "ko70cExuzZM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-fate-of-ophelia/1833328839?i=1833328840"
+                    "url": "https://geo.music.apple.com/us/album/the-fate-of-ophelia/1833328839?i=1833328840"
                 },
                 "spotify": {
                     "id": "53iuhJlwXhSER5J2IYYv1W"
@@ -4373,7 +4373,7 @@
                     "video_id": "XtUWyLOKodA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/everything-is-peaceful-love/1791161215?i=1791161236"
+                    "url": "https://geo.music.apple.com/us/album/everything-is-peaceful-love/1791161215?i=1791161236"
                 },
                 "spotify": {
                     "id": "4XosapYiYaXGcxc83p3DD9"
@@ -4409,7 +4409,7 @@
                     "video_id": "_SVNTv44C4g"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/euro-country/1802736479?i=1802736653"
+                    "url": "https://geo.music.apple.com/us/album/euro-country/1802736479?i=1802736653"
                 },
                 "spotify": {
                     "id": "22vRKcdPjVW7Q6ydLNcYBV"
@@ -4445,7 +4445,7 @@
                     "video_id": "YoH81p_A4j8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-jamie-oliver-petrol-station/1802736479?i=1802736657"
+                    "url": "https://geo.music.apple.com/us/album/the-jamie-oliver-petrol-station/1802736479?i=1802736657"
                 },
                 "spotify": {
                     "id": "3zTqj90l1JdCzBBhxk5Z7U"
@@ -4486,7 +4486,7 @@
                     "video_id": "2Mk7VTUwbck"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tweaker/1859703551?i=1859704245"
+                    "url": "https://geo.music.apple.com/us/album/tweaker/1859703551?i=1859704245"
                 },
                 "spotify": {
                     "id": "7HDq8aEtkBeZq7gfzYjW28"
@@ -4526,7 +4526,7 @@
                     "video_id": "ZZ5ARgm--Ok"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/this-is-real/1796181543?i=1796181548"
+                    "url": "https://geo.music.apple.com/us/album/this-is-real/1796181543?i=1796181548"
                 },
                 "spotify": {
                     "id": "4LYXtoiuM9xEmxklVvQnLl"
@@ -4560,7 +4560,7 @@
                     "video_id": "exxICNaXAKY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/kiss-me-thru-the-phone-pt-2/1821073090?i=1821073394"
+                    "url": "https://geo.music.apple.com/us/album/kiss-me-thru-the-phone-pt-2/1821073090?i=1821073394"
                 },
                 "spotify": {
                     "id": "4SC29UjZqGD3DaZNipthGk"
@@ -4596,7 +4596,7 @@
                     "video_id": "DubtPdXXjew"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-giver/1853697443?i=1853697617"
+                    "url": "https://geo.music.apple.com/us/album/the-giver/1853697443?i=1853697617"
                 },
                 "spotify": {
                     "id": "5xHgo5JN0wfsV41HnRaos5"
@@ -4637,7 +4637,7 @@
                     "video_id": "T90Qd-NFIOc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bounce-house/1797636807?i=1797636814"
+                    "url": "https://geo.music.apple.com/us/album/bounce-house/1797636807?i=1797636814"
                 },
                 "spotify": {
                     "id": "0pfH12vOqokHreQwW5fItt"
@@ -4673,7 +4673,7 @@
                     "video_id": "t7XL4ehHoE0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/one-of-the-greats/1833585853?i=1833586115"
+                    "url": "https://geo.music.apple.com/us/album/one-of-the-greats/1833585853?i=1833586115"
                 },
                 "spotify": {
                     "id": "3qrht50EwYuMgjPkM2A3aJ"
@@ -4704,7 +4704,7 @@
                     "video_id": "fpIHEHs-zck"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/au-pays-du-cocaine/1818548779?i=1818549165"
+                    "url": "https://geo.music.apple.com/us/album/au-pays-du-cocaine/1818548779?i=1818549165"
                 },
                 "spotify": {
                     "id": "1g9GiiPPaL7KcDHlDzu7lT"
@@ -4740,7 +4740,7 @@
                     "video_id": "Xgp7wlBfASA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/house-featuring-john-cale/1851605885?i=1851605886"
+                    "url": "https://geo.music.apple.com/us/album/house-featuring-john-cale/1851605885?i=1851605886"
                 },
                 "spotify": {
                     "id": "6lYUgmE829m06SMC6tG3qD"
@@ -4775,7 +4775,7 @@
                     "video_id": "q_nwxIIUVAw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tourmaline/1836925829?i=1836925833"
+                    "url": "https://geo.music.apple.com/us/album/tourmaline/1836925829?i=1836925833"
                 },
                 "spotify": {
                     "id": "7sam5WsFimXgFOCuEOc90x"
@@ -4805,7 +4805,7 @@
                     "video_id": "EllglEuFQkY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dogeared-feat-kapwani/1832310241?i=1832310610"
+                    "url": "https://geo.music.apple.com/us/album/dogeared-feat-kapwani/1832310241?i=1832310610"
                 },
                 "spotify": {
                     "id": "1iqzScqn13kZlzym0Uyina"
@@ -4839,7 +4839,7 @@
                     "video_id": "VUvqvvTLKNA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hard/1860834516?i=1860835298"
+                    "url": "https://geo.music.apple.com/us/album/hard/1860834516?i=1860835298"
                 },
                 "spotify": {
                     "id": "5AzO8bswSqsYtJIfVA2BqX"
@@ -4870,7 +4870,7 @@
                     "video_id": "Dnmgy81Dh8A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/afraid/1859703551?i=1859703949"
+                    "url": "https://geo.music.apple.com/us/album/afraid/1859703551?i=1859703949"
                 },
                 "spotify": {
                     "id": "41YlWhySoJVw2TXaxW1q5G"
@@ -4901,7 +4901,7 @@
                     "video_id": "jC0pjkRpC6s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/makka/1814082388?i=1814082389"
+                    "url": "https://geo.music.apple.com/us/album/makka/1814082388?i=1814082389"
                 },
                 "spotify": {
                     "id": "4JxgNwic9PMF1c87TKWZOr"
@@ -4927,7 +4927,7 @@
                     "video_id": "fss1gPMW1Wo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ivonny-bonita/1819544141?i=1819544163"
+                    "url": "https://geo.music.apple.com/us/album/ivonny-bonita/1819544141?i=1819544163"
                 },
                 "spotify": {
                     "id": "6Sv0CzVqzydd7NYQgAG70c"
@@ -4953,7 +4953,7 @@
                     "video_id": "Ecdysis"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ecdysis/1825435148?i=1825435152"
+                    "url": "https://geo.music.apple.com/us/album/ecdysis/1825435148?i=1825435152"
                 },
                 "spotify": {
                     "id": "4JV3BjszeEUD1bTTcx9hdx"
@@ -4983,7 +4983,7 @@
                     "video_id": "9TAygb2M8k8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dior-leopard/1860438163?i=1860438609"
+                    "url": "https://geo.music.apple.com/us/album/dior-leopard/1860438163?i=1860438609"
                 },
                 "spotify": {
                     "id": "7kQSYTf3fA2DYl4NbTzSzS"
@@ -5014,7 +5014,7 @@
                     "video_id": "gELPTAADiZs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/deep-diving/1824309844?i=1824309845"
+                    "url": "https://geo.music.apple.com/us/album/deep-diving/1824309844?i=1824309845"
                 },
                 "spotify": {
                     "id": "4Ji5pXYxvpxIAR87YGGx3Q"
@@ -5045,7 +5045,7 @@
                     "video_id": "9BInZVKHVAU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/f-i-c-o/1862672249?i=1862672502"
+                    "url": "https://geo.music.apple.com/us/album/f-i-c-o/1862672249?i=1862672502"
                 },
                 "spotify": {
                     "id": "6X5sXeRwqbqPsZ8FFFae0F"
@@ -5076,7 +5076,7 @@
                     "video_id": "sP0us82q1ck"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nettles/1818431571?i=1818431577"
+                    "url": "https://geo.music.apple.com/us/album/nettles/1818431571?i=1818431577"
                 },
                 "spotify": {
                     "id": "02kTd6gB8IsBwPygDTHE4c"
@@ -5102,7 +5102,7 @@
                     "video_id": "IrEFKJnl1H8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tonight/1843595790?i=1843596036"
+                    "url": "https://geo.music.apple.com/us/album/tonight/1843595790?i=1843596036"
                 },
                 "spotify": {
                     "id": "5QCfOMH5K7bS4dH7H7PNeI"
@@ -5138,7 +5138,7 @@
                     "video_id": "CjnFzPhM72I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/flash/1803726233?i=1803726236"
+                    "url": "https://geo.music.apple.com/us/album/flash/1803726233?i=1803726236"
                 },
                 "spotify": {
                     "id": "46bUjfJt7SVePcWtBVKa7W"
@@ -5169,7 +5169,7 @@
                     "video_id": "13uFAzc5Lvc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tears-on-his-rings-and-chains/1833008599?i=1833008600"
+                    "url": "https://geo.music.apple.com/us/album/tears-on-his-rings-and-chains/1833008599?i=1833008600"
                 },
                 "spotify": {
                     "id": "7DigNxE6prVBzj4sPJopkT"
@@ -5271,7 +5271,7 @@
                     "video_id": "0Zy1_ZbBbJg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/t-a/1843241022?i=1843241098"
+                    "url": "https://geo.music.apple.com/us/album/t-a/1843241022?i=1843241098"
                 },
                 "spotify": {
                     "id": "1KuJP2mJPtCXe1aeXXPvSP"
@@ -5302,7 +5302,7 @@
                     "video_id": "beNFK2cdnKU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/times-like-these/1809015416?i=1809015882"
+                    "url": "https://geo.music.apple.com/us/album/times-like-these/1809015416?i=1809015882"
                 },
                 "spotify": {
                     "id": "01fzY6YKwKQ3LxCpIP6buB"
@@ -5333,7 +5333,7 @@
                     "video_id": "ALwSLZkTIb4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/a-lister/1812935292?i=1812935296"
+                    "url": "https://geo.music.apple.com/us/album/a-lister/1812935292?i=1812935296"
                 },
                 "spotify": {
                     "id": "7GRPnTVWiFqlC3EAvFiKvY"
@@ -5364,7 +5364,7 @@
                     "video_id": "F0cdbR5ognY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/denial-is-a-river/1804213280?i=1804213292"
+                    "url": "https://geo.music.apple.com/us/album/denial-is-a-river/1804213280?i=1804213292"
                 },
                 "spotify": {
                     "id": "1eTaznNW4Xxtx9za2SMTXB"
@@ -5418,7 +5418,7 @@
                     "video_id": "a_0DYKvcjCE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mind-loaded-feat-caroline-polachek-lorde-mustafa/1825903903?i=1825903912"
+                    "url": "https://geo.music.apple.com/us/album/mind-loaded-feat-caroline-polachek-lorde-mustafa/1825903903?i=1825903912"
                 },
                 "spotify": {
                     "id": "04KHyqdGs5sVEWX6UnukF2"
@@ -5449,7 +5449,7 @@
                     "video_id": "9qoNd60GcIA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hot-body/1827385188?i=1827385189"
+                    "url": "https://geo.music.apple.com/us/album/hot-body/1827385188?i=1827385189"
                 },
                 "spotify": {
                     "id": "04yGQ4xzVt9LVAqop42ja6"
@@ -5479,7 +5479,7 @@
                     "video_id": "jV4fWZIlprI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cataract-time/1839207466?i=1839207845"
+                    "url": "https://geo.music.apple.com/us/album/cataract-time/1839207466?i=1839207845"
                 },
                 "spotify": {
                     "id": "0UF9UVGNlZ12xDzzhjOrRd"
@@ -5515,7 +5515,7 @@
                     "video_id": "jmvCwjzpfuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/spiders/1819085978?i=1819085988"
+                    "url": "https://geo.music.apple.com/us/album/spiders/1819085978?i=1819085988"
                 },
                 "spotify": {
                     "id": "39js1Jxh1R29ht4mAvTdBr"
@@ -5551,7 +5551,7 @@
                     "video_id": "hE2DLtuxcUU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nobodys-son/1819861154?i=1819861163"
+                    "url": "https://geo.music.apple.com/us/album/nobodys-son/1819861154?i=1819861163"
                 },
                 "spotify": {
                     "id": "4SRShYMtFIGgnOU7iBicMH"
@@ -5577,7 +5577,7 @@
                     "video_id": "QqzXvvdk3bQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/com%C3%AB-n-go/1830346710?i=1830346719"
+                    "url": "https://geo.music.apple.com/us/album/com%C3%AB-n-go/1830346710?i=1830346719"
                 },
                 "spotify": {
                     "id": "2mNGL7mZILSqZHxGboJaO9"
@@ -5608,7 +5608,7 @@
                     "video_id": "08C987fQEKU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/victory-lap/1857568186?i=1857568277"
+                    "url": "https://geo.music.apple.com/us/album/victory-lap/1857568186?i=1857568277"
                 },
                 "spotify": {
                     "id": "1lbNgoJ5iMrMluCyhI4OQP"
@@ -5639,7 +5639,7 @@
                     "video_id": "c8zq4kAn_O0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/back-to-friends/1832087626?i=1832087996"
+                    "url": "https://geo.music.apple.com/us/album/back-to-friends/1832087626?i=1832087996"
                 },
                 "spotify": {
                     "id": "7qjZnBKE73H4Oxkopwulqe"
@@ -5670,7 +5670,7 @@
                     "video_id": "gJ2aMxKjAC4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ankles/1844471188?i=1844471419"
+                    "url": "https://geo.music.apple.com/us/album/ankles/1844471188?i=1844471419"
                 },
                 "spotify": {
                     "id": "4VhbsGXRGDncpi79aiX8eE"
@@ -5696,7 +5696,7 @@
                     "video_id": "TTs9D1R2Ttw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/get-jiggy/1809798586?i=1809799190"
+                    "url": "https://geo.music.apple.com/us/album/get-jiggy/1809798586?i=1809799190"
                 },
                 "spotify": {
                     "id": "55NuTxRk1TyKzpgD8dC1IY"
@@ -5731,7 +5731,7 @@
                     "video_id": "Pa4cdGquSiM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/misery-feat-kenny-segal/1793411266?i=1793411993"
+                    "url": "https://geo.music.apple.com/us/album/misery-feat-kenny-segal/1793411266?i=1793411993"
                 },
                 "spotify": {
                     "id": "77VBQKutkIrMfr7PPvZWdA"
@@ -5767,7 +5767,7 @@
                     "video_id": "e2G746ZmejQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/room-of-fools/1852333140?i=1852333156"
+                    "url": "https://geo.music.apple.com/us/album/room-of-fools/1852333140?i=1852333156"
                 },
                 "spotify": {
                     "id": "1CqyErlQstROOe9hAn93oI"
@@ -5798,7 +5798,7 @@
                     "video_id": "ydoSpHB7KiE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bitin-list/1818393806?i=1818394050"
+                    "url": "https://geo.music.apple.com/us/album/bitin-list/1818393806?i=1818394050"
                 },
                 "spotify": {
                     "id": "0x5wJ0cDp7miv49jSMTSkq"
@@ -5828,7 +5828,7 @@
                     "video_id": "Jrf8N1EMUhg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/changes/1853587303?i=1853587845"
+                    "url": "https://geo.music.apple.com/us/album/changes/1853587303?i=1853587845"
                 },
                 "spotify": {
                     "id": "4kUI0vuDd0Zub4IvxxNreM"
@@ -5859,7 +5859,7 @@
                     "video_id": "F1oKhsy8wGw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sally-when-the-wine-runs-out/1831864510?i=1831864782"
+                    "url": "https://geo.music.apple.com/us/album/sally-when-the-wine-runs-out/1831864510?i=1831864782"
                 },
                 "spotify": {
                     "id": "2J051fjLklkoPbzOoTAACZ"
@@ -5895,7 +5895,7 @@
                     "video_id": "VI0NDsh2b8k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nice-to-each-other/1861635146?i=1861635147"
+                    "url": "https://geo.music.apple.com/us/album/nice-to-each-other/1861635146?i=1861635147"
                 },
                 "spotify": {
                     "id": "7gKxCvTDWwV9wBhdeBbr3l"
@@ -5931,7 +5931,7 @@
                     "video_id": "1UpoZpMBM9Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/what-was-that/1835458110?i=1835458483"
+                    "url": "https://geo.music.apple.com/us/album/what-was-that/1835458110?i=1835458483"
                 },
                 "spotify": {
                     "id": "7hGCCQkdyF1MX6uk339uBS"
@@ -5957,7 +5957,7 @@
                     "video_id": "495zc7_vGgA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/went-legit/1826166664?i=1826166833"
+                    "url": "https://geo.music.apple.com/us/album/went-legit/1826166664?i=1826166833"
                 },
                 "spotify": {
                     "id": "2I9517MJ7979KTtFjbDo5E"
@@ -5983,7 +5983,7 @@
                     "video_id": "YJNFAaWJhp0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hard-fought-hallelujah/1804395857?i=1804396310"
+                    "url": "https://geo.music.apple.com/us/album/hard-fought-hallelujah/1804395857?i=1804396310"
                 },
                 "spotify": {
                     "id": "4cLC8gydI0O78g8chZugS4"
@@ -6009,7 +6009,7 @@
                     "video_id": "m1tZUp9gR04"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ill-be-there/1791161215?i=1791161561"
+                    "url": "https://geo.music.apple.com/us/album/ill-be-there/1791161215?i=1791161561"
                 },
                 "spotify": {
                     "id": "5Lf2llKUYgSakzMejYowOu"
@@ -6045,7 +6045,7 @@
                     "video_id": "RiwEzF3DsGk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jrjrjr/1800020675?i=1800020722"
+                    "url": "https://geo.music.apple.com/us/album/jrjrjr/1800020675?i=1800020722"
                 },
                 "spotify": {
                     "id": "1mW9XrT9XdnsDPuthSgusZ"
@@ -6089,7 +6089,7 @@
                     "video_id": "ZqgKKbg2Ja8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sue-me/1826574954?i=1826575254"
+                    "url": "https://geo.music.apple.com/us/album/sue-me/1826574954?i=1826575254"
                 },
                 "spotify": {
                     "id": "6ZAuQOgLrNQb9s7BXheuTy"
@@ -6120,7 +6120,7 @@
                     "video_id": "LVBs4LsveNA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jody/1782385716?i=1782386284"
+                    "url": "https://geo.music.apple.com/us/album/jody/1782385716?i=1782386284"
                 },
                 "spotify": {
                     "id": "65BLWgYIxnhe0GSSAt7laa"
@@ -6146,7 +6146,7 @@
                     "video_id": "vshBgfqkxBI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oh-ok-xxl-freestyle/1824565451?i=1824565467"
+                    "url": "https://geo.music.apple.com/us/album/oh-ok-xxl-freestyle/1824565451?i=1824565467"
                 },
                 "spotify": {
                     "id": "555oowE8kujtS6bR2GOOPD"
@@ -6172,7 +6172,7 @@
                     "video_id": "OfpHdp6fgSA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/corinthians-feat-despot-el-p/1793411266?i=1793412014"
+                    "url": "https://geo.music.apple.com/us/album/corinthians-feat-despot-el-p/1793411266?i=1793412014"
                 },
                 "spotify": {
                     "id": "1nyWOn19RBU0J9LIzgfNJK"
@@ -6198,7 +6198,7 @@
                     "video_id": "czjlIwVM8Kc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/higher/1832337743?i=1832337756"
+                    "url": "https://geo.music.apple.com/us/album/higher/1832337743?i=1832337756"
                 },
                 "spotify": {
                     "id": "0XnD9GJRD01wvXFLWJXiYx"
@@ -6234,7 +6234,7 @@
                     "video_id": "4kCVGodVS88"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/back-to-me/1803199495?i=1803199508"
+                    "url": "https://geo.music.apple.com/us/album/back-to-me/1803199495?i=1803199508"
                 },
                 "spotify": {
                     "id": "4E0P1xs3JNmsNr5c5nFTZJ"
@@ -6259,7 +6259,7 @@
                     "video_id": "zx0XfI0ola0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/everyone-falls-asleep-in-their-own-time/1812702904?i=1812702905"
+                    "url": "https://geo.music.apple.com/us/album/everyone-falls-asleep-in-their-own-time/1812702904?i=1812702905"
                 },
                 "spotify": {
                     "id": "7sGYT6ewCCJ5KJvWP1n3MP"
@@ -6285,7 +6285,7 @@
                     "video_id": "TORQHzYF1NU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/baby/1832337743?i=1832337744"
+                    "url": "https://geo.music.apple.com/us/album/baby/1832337743?i=1832337744"
                 },
                 "spotify": {
                     "id": "6Qgy3ikLFnJsJ7xHL0mayF"
@@ -6311,7 +6311,7 @@
                     "video_id": "DXUoMJs80RQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/paw/1863205461?i=1863205696"
+                    "url": "https://geo.music.apple.com/us/album/paw/1863205461?i=1863205696"
                 },
                 "spotify": {
                     "id": "5u7QDciPfgcpmoqRtp6zk6"
@@ -6342,7 +6342,7 @@
                     "video_id": "m95ZCq4mQrE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/look-out-for-me/1825416104?i=1825416881"
+                    "url": "https://geo.music.apple.com/us/album/look-out-for-me/1825416104?i=1825416881"
                 },
                 "spotify": {
                     "id": "4gM6AHXp4h8aj5482znmYz"
@@ -6373,7 +6373,7 @@
                     "video_id": "MlnRO2FwojA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tetas/1797880735?i=1797880739"
+                    "url": "https://geo.music.apple.com/us/album/tetas/1797880735?i=1797880739"
                 },
                 "spotify": {
                     "id": "2RAKwOzLiXA8AgA1pFIuFe"
@@ -6409,7 +6409,7 @@
                     "video_id": "CgCVZdcKcqY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jump/1824672650?i=1824672652"
+                    "url": "https://geo.music.apple.com/us/album/jump/1824672650?i=1824672652"
                 },
                 "spotify": {
                     "id": "5H1sKFMzDeMtXwND3V6hRY"
@@ -6458,7 +6458,7 @@
                     "video_id": "Xtq_A2NnHKQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dark-thoughts/1858748966?i=1858749192"
+                    "url": "https://geo.music.apple.com/us/album/dark-thoughts/1858748966?i=1858749192"
                 },
                 "spotify": {
                     "id": "7EW7Yivb93qKAtp5qEm5of"
@@ -6522,7 +6522,7 @@
                     "video_id": "vfsg12xVUVo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/milk-of-the-madonna/1825435148?i=1825435159"
+                    "url": "https://geo.music.apple.com/us/album/milk-of-the-madonna/1825435148?i=1825435159"
                 },
                 "spotify": {
                     "id": "2463q6UN8BIDfeVI379qFz"
@@ -6553,7 +6553,7 @@
                     "video_id": "WQCPl5rTMDQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ruin-the-friendship/1838810949?i=1838810957"
+                    "url": "https://geo.music.apple.com/us/album/ruin-the-friendship/1838810949?i=1838810957"
                 },
                 "spotify": {
                     "id": "62V2ZHslgQV98gH4AuVXnr"
@@ -6578,7 +6578,7 @@
                     "video_id": "STP4cCpyScE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/obvious/1779808073?i=1779808079"
+                    "url": "https://geo.music.apple.com/us/album/obvious/1779808073?i=1779808079"
                 },
                 "spotify": {
                     "id": "7zyBL0LZndcnPXsbdhiqWp"
@@ -6604,7 +6604,7 @@
                     "video_id": "03AZjPWL7zo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ptp-feat-monaleo-remix/1797646163?i=1797646164"
+                    "url": "https://geo.music.apple.com/us/album/ptp-feat-monaleo-remix/1797646163?i=1797646164"
                 },
                 "spotify": {
                     "id": "5nZ73ycbCA2lkEyuM1K6zB"
@@ -6630,7 +6630,7 @@
                     "video_id": "cLx3tyzht3Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/last-shot/1832097285?i=1832097286"
+                    "url": "https://geo.music.apple.com/us/album/last-shot/1832097285?i=1832097286"
                 },
                 "spotify": {
                     "id": "5ppdmIeHPG2qLHm0SsmqfB"
@@ -6661,7 +6661,7 @@
                     "video_id": "UNYqwpx7Cys"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/music/1819612562?i=1819612563"
+                    "url": "https://geo.music.apple.com/us/album/music/1819612562?i=1819612563"
                 },
                 "spotify": {
                     "id": "3hut1ozNEFwZ8W1rxATaH9"
@@ -6692,7 +6692,7 @@
                     "video_id": "vU0Q8DKWhQk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/straight-line-was-a-lie/1817137575?i=1817137576"
+                    "url": "https://geo.music.apple.com/us/album/straight-line-was-a-lie/1817137575?i=1817137576"
                 },
                 "spotify": {
                     "id": "1KpAjuTO2M9eYnaGz6uoTc"
@@ -6723,7 +6723,7 @@
                     "video_id": "ulkdUfItyxI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/end-of-summer/1836226516?i=1836226739"
+                    "url": "https://geo.music.apple.com/us/album/end-of-summer/1836226516?i=1836226739"
                 },
                 "spotify": {
                     "id": "3McBKxKZLXbE4czUezk5QG"
@@ -6759,7 +6759,7 @@
                     "video_id": "kWdBbX8VPko"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/standing-on-air/1815704522?i=1815704531"
+                    "url": "https://geo.music.apple.com/us/album/standing-on-air/1815704522?i=1815704531"
                 },
                 "spotify": {
                     "id": "1K9d3btZvnxKfYd4uHJ8Os"
@@ -6793,7 +6793,7 @@
                     "video_id": "brJtbkV6Yq4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wthelly/1822864598?i=1822864712"
+                    "url": "https://geo.music.apple.com/us/album/wthelly/1822864598?i=1822864712"
                 },
                 "spotify": {
                     "id": "03gyVoP8A8A3mdcGMxcHqD"
@@ -6824,7 +6824,7 @@
                     "video_id": "7kyHvPNbugk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/all-the-way/1835563848?i=1835563853"
+                    "url": "https://geo.music.apple.com/us/album/all-the-way/1835563848?i=1835563853"
                 },
                 "spotify": {
                     "id": "59F5qOMpqqclD21cIAxFEo"
@@ -6855,7 +6855,7 @@
                     "video_id": "4FUIEcnvT04"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/opalite/1838810949?i=1838810953"
+                    "url": "https://geo.music.apple.com/us/album/opalite/1838810949?i=1838810953"
                 },
                 "spotify": {
                     "id": "3yWuTOYDztXjZxdE2cIRUa"
@@ -6886,7 +6886,7 @@
                     "video_id": "6ZWhNxslxzA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dreamflasher/1838000412?i=1838000413"
+                    "url": "https://geo.music.apple.com/us/album/dreamflasher/1838000412?i=1838000413"
                 },
                 "spotify": {
                     "id": "75Wgg4LerPD3mVO5hEyUN9"
@@ -6917,7 +6917,7 @@
                     "video_id": "VcRc2DHHhoM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/evil-j0rdan/1802175271?i=1802175276"
+                    "url": "https://geo.music.apple.com/us/album/evil-j0rdan/1802175271?i=1802175276"
                 },
                 "spotify": {
                     "id": "6iycYUk3oB0NPMdaDUrN1w"
@@ -6948,7 +6948,7 @@
                     "video_id": "ZTEmDLkUC1U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/look-down-on-us/1812874747?i=1812874748"
+                    "url": "https://geo.music.apple.com/us/album/look-down-on-us/1812874747?i=1812874748"
                 },
                 "spotify": {
                     "id": "3KQFlED2WlEBOFRK61eI05"
@@ -6973,7 +6973,7 @@
                     "video_id": "biCUa5Oa2GQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/4/1794764757?i=1794764761"
+                    "url": "https://geo.music.apple.com/us/album/4/1794764757?i=1794764761"
                 },
                 "spotify": {
                     "id": "3W9INBEJLZwnBZlbGHz8P2"
@@ -6999,7 +6999,7 @@
                     "video_id": "Z0-mbAxxd8E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tennis/1846342052?i=1846342300"
+                    "url": "https://geo.music.apple.com/us/album/tennis/1846342052?i=1846342300"
                 },
                 "spotify": {
                     "id": "6WQsY2YMdIQWoOm9MyZMWR"
@@ -7035,7 +7035,7 @@
                     "video_id": "Nfk1Su1Q8SI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/never-enough/1824394449?i=1824395636"
+                    "url": "https://geo.music.apple.com/us/album/never-enough/1824394449?i=1824395636"
                 },
                 "spotify": {
                     "id": "1zoXDi9AY4TF5JoUuCCTL6"
@@ -7066,7 +7066,7 @@
                     "video_id": "ziYOZyAE3mE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bodhidharma/1821247551?i=1821247559"
+                    "url": "https://geo.music.apple.com/us/album/bodhidharma/1821247551?i=1821247559"
                 },
                 "spotify": {
                     "id": "1NoYnWzMQ1mY67jo7gDakq"
@@ -7097,7 +7097,7 @@
                     "video_id": "L9XBol_Vafs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/autumn/1785291029?i=1785291033"
+                    "url": "https://geo.music.apple.com/us/album/autumn/1785291029?i=1785291033"
                 },
                 "spotify": {
                     "id": "0tffcBUiW3TMTjdhkgvEww"
@@ -7126,7 +7126,7 @@
                     "video_id": "asnVsJf4esU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ran-out/1802764142?i=1802764144"
+                    "url": "https://geo.music.apple.com/us/album/ran-out/1802764142?i=1802764144"
                 },
                 "spotify": {
                     "id": "6gR9K14ED3UuhVIu4t9LTk"
@@ -7180,7 +7180,7 @@
                     "video_id": "T2fQwT3y_fI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/basho/1791832159?i=1791832160"
+                    "url": "https://geo.music.apple.com/us/album/basho/1791832159?i=1791832160"
                 },
                 "spotify": {
                     "id": "5sKMHfvZBvZAXWJLaoj5TI"
@@ -7216,7 +7216,7 @@
                     "video_id": "ddkbVYutRXA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/marlboro-rojo/1811903274?i=1811903401"
+                    "url": "https://geo.music.apple.com/us/album/marlboro-rojo/1811903274?i=1811903401"
                 },
                 "spotify": {
                     "id": "3hpm0fTeSqlhJbnqAgaLZs"
@@ -7247,7 +7247,7 @@
                     "video_id": "HIcjeZtpJs4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/man-of-the-year/1859044959?i=1859045371"
+                    "url": "https://geo.music.apple.com/us/album/man-of-the-year/1859044959?i=1859045371"
                 },
                 "spotify": {
                     "id": "1gvOEwQbIEjkpLdcZwtBoB"
@@ -7278,7 +7278,7 @@
                     "video_id": "i36-wzw2g7k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/delusional/1810025525?i=1810025823"
+                    "url": "https://geo.music.apple.com/us/album/delusional/1810025525?i=1810025823"
                 },
                 "spotify": {
                     "id": "6M5Y8sn5cXePK58bH1WKon"
@@ -7309,7 +7309,7 @@
                     "video_id": "PKwDjGu-QCg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cross-your-mind/1818928365?i=1818928366"
+                    "url": "https://geo.music.apple.com/us/album/cross-your-mind/1818928365?i=1818928366"
                 },
                 "spotify": {
                     "id": "3a3zDlE4bgI6ZvU00m6o84"
@@ -7340,7 +7340,7 @@
                     "video_id": "nDYY3nJ7a0s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/henry-come-on/1807425305?i=1807425306"
+                    "url": "https://geo.music.apple.com/us/album/henry-come-on/1807425305?i=1807425306"
                 },
                 "spotify": {
                     "id": "6CYldrsUPBsiPtfLW4xZCl"
@@ -7366,7 +7366,7 @@
                     "video_id": "h9dmMpOQ8ik"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/out-in-the-garden/1839114266?i=1839114267"
+                    "url": "https://geo.music.apple.com/us/album/out-in-the-garden/1839114266?i=1839114267"
                 },
                 "spotify": {
                     "id": "5uGegogwUJ9g8caxaqVzoe"
@@ -7391,7 +7391,7 @@
                     "video_id": "BE0QRWynyvM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ghost/1806107071?i=1806107076"
+                    "url": "https://geo.music.apple.com/us/album/ghost/1806107071?i=1806107076"
                 },
                 "spotify": {
                     "id": "35TWPLjC6Iak3kAaA5yldE"
@@ -7417,7 +7417,7 @@
                     "video_id": "hJXXG50Ix4A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oil-money/1794891244?i=1794891246"
+                    "url": "https://geo.music.apple.com/us/album/oil-money/1794891244?i=1794891246"
                 },
                 "spotify": {
                     "id": "1HZECMqLKSh22jwPv3yRYm"
@@ -7443,7 +7443,7 @@
                     "video_id": "VzLwY18tt8M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hecho-para-ti/1826189410?i=1826189414"
+                    "url": "https://geo.music.apple.com/us/album/hecho-para-ti/1826189410?i=1826189414"
                 },
                 "spotify": {
                     "id": "712KzUVmtBeFXgJhbMJY5o"
@@ -7469,7 +7469,7 @@
                     "video_id": "_tP2v3l81b8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/believer/1797843755?i=1797844368"
+                    "url": "https://geo.music.apple.com/us/album/believer/1797843755?i=1797844368"
                 },
                 "spotify": {
                     "id": "6gLOkCljeiC4m4bJj6BT8l"
@@ -7500,7 +7500,7 @@
                     "video_id": "aFKifAWIesU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gallic-shrug/1803343332?i=1803343336"
+                    "url": "https://geo.music.apple.com/us/album/gallic-shrug/1803343332?i=1803343336"
                 },
                 "spotify": {
                     "id": "1EmJUalp1RWAHrmmqOYARH"
@@ -7526,7 +7526,7 @@
                     "video_id": "45puzF8wu6g"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/porcelana/1848167516?i=1848167524"
+                    "url": "https://geo.music.apple.com/us/album/porcelana/1848167516?i=1848167524"
                 },
                 "spotify": {
                     "id": "3hETtcSLmNncBjPMLHtVZs"
@@ -7557,7 +7557,7 @@
                     "video_id": "CoAxLiVZyQg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pick-up-that-knife/1807870796?i=1807870811"
+                    "url": "https://geo.music.apple.com/us/album/pick-up-that-knife/1807870796?i=1807870811"
                 },
                 "spotify": {
                     "id": "5NRbeq1mnwgyWeVJzOivmT"
@@ -7583,7 +7583,7 @@
                     "video_id": "UjYTDZAyHC8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/blkwmn/1805663273?i=1805663288"
+                    "url": "https://geo.music.apple.com/us/album/blkwmn/1805663273?i=1805663288"
                 },
                 "spotify": {
                     "id": "6zDsdi08Ym7zx7tjSilIks"
@@ -7609,7 +7609,7 @@
                     "video_id": "qlYAYqrTwS4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/between-the-ditches/1819596977?i=1819596991"
+                    "url": "https://geo.music.apple.com/us/album/between-the-ditches/1819596977?i=1819596991"
                 },
                 "spotify": {
                     "id": "7u9dkCGGRSepXhCQUy3Nzm"
@@ -7635,7 +7635,7 @@
                     "video_id": "fZCtDdEwq0s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/spangled/1782385716?i=1782385720"
+                    "url": "https://geo.music.apple.com/us/album/spangled/1782385716?i=1782385720"
                 },
                 "spotify": {
                     "id": "0w3ptVGmlBJLWqwsrnrGnO"
@@ -7661,7 +7661,7 @@
                     "video_id": "m54gLJk_BTY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tip/1828259285?i=1828259306"
+                    "url": "https://geo.music.apple.com/us/album/tip/1828259285?i=1828259306"
                 },
                 "spotify": {
                     "id": "2yy0GLEoyeluaBXUJysaXE"
@@ -7687,7 +7687,7 @@
                     "video_id": "qkTOy80RxNo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/como-quisiera-quererte/1801618079?i=1801618378"
+                    "url": "https://geo.music.apple.com/us/album/como-quisiera-quererte/1801618079?i=1801618378"
                 },
                 "spotify": {
                     "id": "5gGOOM1oDSQ59lcGOXIvZL"
@@ -7713,7 +7713,7 @@
                     "video_id": "yzfcuwhFyGQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/snapping-turtle/1799811094?i=1799811100"
+                    "url": "https://geo.music.apple.com/us/album/snapping-turtle/1799811094?i=1799811100"
                 },
                 "spotify": {
                     "id": "4dUR3x8NPEgD2lvtavZp5p"
@@ -7739,7 +7739,7 @@
                     "video_id": "udw9amI1qkA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dudu/1790541064?i=1790541070"
+                    "url": "https://geo.music.apple.com/us/album/dudu/1790541064?i=1790541070"
                 },
                 "spotify": {
                     "id": "5vkJZHiK2s7Os8AM1vInjv"
@@ -7765,7 +7765,7 @@
                     "video_id": "5SPhwnfpgsM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/praying-for-your-downfall/1792515736?i=1792516240"
+                    "url": "https://geo.music.apple.com/us/album/praying-for-your-downfall/1792515736?i=1792516240"
                 },
                 "spotify": {
                     "id": "09I4z4KlAHUJcG9Atd9UvF"
@@ -7791,7 +7791,7 @@
                     "video_id": "e4hiGvSZEHI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gadabout-season/1807621385?i=1807621750"
+                    "url": "https://geo.music.apple.com/us/album/gadabout-season/1807621385?i=1807621750"
                 },
                 "spotify": {
                     "id": "5Z4YeqJLy2Ik0NYr0xlfh7"
@@ -7817,7 +7817,7 @@
                     "video_id": "rUmKx63oV20"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/aint-it-nice/1815975604?i=1815975876"
+                    "url": "https://geo.music.apple.com/us/album/aint-it-nice/1815975604?i=1815975876"
                 },
                 "spotify": {
                     "id": "16cf5KXlcTvSpO1TisvQWI"
@@ -7843,7 +7843,7 @@
                     "video_id": "B0MwOCefHus"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/on-the-low/1806081803?i=1806082026"
+                    "url": "https://geo.music.apple.com/us/album/on-the-low/1806081803?i=1806082026"
                 },
                 "spotify": {
                     "id": "4OfDp6aSHjkeECflD1v82U"
@@ -7869,7 +7869,7 @@
                     "video_id": "nT43dsYhw0k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/trinidad/1828810599?i=1828810600"
+                    "url": "https://geo.music.apple.com/us/album/trinidad/1828810599?i=1828810600"
                 },
                 "spotify": {
                     "id": "5WGr8oEBp2RBrorc5ZEx1K"
@@ -7900,7 +7900,7 @@
                     "video_id": "TfzcvmvThQA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/heaven-song/1799811094?i=1799811377"
+                    "url": "https://geo.music.apple.com/us/album/heaven-song/1799811094?i=1799811377"
                 },
                 "spotify": {
                     "id": "7Cx6yqhM7WSxrLMW2ZRulF"
@@ -7931,7 +7931,7 @@
                     "video_id": "rvdWce1gSvs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/woes-of-the-world/1792985706?i=1792985714"
+                    "url": "https://geo.music.apple.com/us/album/woes-of-the-world/1792985706?i=1792985714"
                 },
                 "spotify": {
                     "id": "63QsCkpO2egX2zaqBAcyrh"
@@ -7957,7 +7957,7 @@
                     "video_id": "cI9t6MqMyUk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/new-bad/1789001505?i=1789001947"
+                    "url": "https://geo.music.apple.com/us/album/new-bad/1789001505?i=1789001947"
                 },
                 "spotify": {
                     "id": "4KUd1EBo8cWkWsI3sdoZTy"
@@ -7983,7 +7983,7 @@
                     "video_id": "1G7MtORcvTo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/loose-leaf/1793465453?i=1793465460"
+                    "url": "https://geo.music.apple.com/us/album/loose-leaf/1793465453?i=1793465460"
                 },
                 "spotify": {
                     "id": "6CZUlSprqREfKDdmTxVkDx"
@@ -8009,7 +8009,7 @@
                     "video_id": "OKVi6jPdE8c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dont-tap-that-glass-tweakin/1827715784?i=1827715798"
+                    "url": "https://geo.music.apple.com/us/album/dont-tap-that-glass-tweakin/1827715784?i=1827715798"
                 },
                 "spotify": {
                     "id": "5DRS7YEe1bwGJLDGviT3CD"
@@ -8034,7 +8034,7 @@
                     "video_id": "lW2xfg2Cr6Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/die-trying/1796127242?i=1796127376"
+                    "url": "https://geo.music.apple.com/us/album/die-trying/1796127242?i=1796127376"
                 },
                 "spotify": {
                     "id": "0NUqi0ps17YpLUC3kgsZq0"
@@ -8065,7 +8065,7 @@
                     "video_id": "nnzndZQX3SU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dont-let-the-bastards-get-you-down/1814683632?i=1814683646"
+                    "url": "https://geo.music.apple.com/us/album/dont-let-the-bastards-get-you-down/1814683632?i=1814683646"
                 },
                 "spotify": {
                     "id": "2UhaV3bOXEIzmbiVhnVZKY"
@@ -8101,7 +8101,7 @@
                     "video_id": "vRBa34X5Hwg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/thus-is-why-i-dont-spring-4-love/1755473266?i=1755473268"
+                    "url": "https://geo.music.apple.com/us/album/thus-is-why-i-dont-spring-4-love/1755473266?i=1755473268"
                 },
                 "spotify": {
                     "id": "29UD619bhwDjNXvuSh6cDz"
@@ -8127,7 +8127,7 @@
                     "video_id": "HdT1MLcKqQA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/when-a-good-man-cries/1831270117?i=1831270120"
+                    "url": "https://geo.music.apple.com/us/album/when-a-good-man-cries/1831270117?i=1831270120"
                 },
                 "spotify": {
                     "id": "6VXIZWHmdOTHIFhsSkYFgQ"
@@ -8153,7 +8153,7 @@
                     "video_id": "eqKhhG4FVoQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/focus/1841828519?i=1841828520"
+                    "url": "https://geo.music.apple.com/us/album/focus/1841828519?i=1841828520"
                 },
                 "spotify": {
                     "id": "6jYiHr12NVKLzn0X7K8aSK"
@@ -8178,7 +8178,7 @@
                     "video_id": "AaPdQtQtfO8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/chlorine/1812106193?i=1812106374"
+                    "url": "https://geo.music.apple.com/us/album/chlorine/1812106193?i=1812106374"
                 },
                 "spotify": {
                     "id": "0n1CfnJxvLVSVK4zAbuviH"
@@ -8204,7 +8204,7 @@
                     "video_id": "boW8dbVEbQ4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tomorrow-will-be-better/1796481646?i=1796481647"
+                    "url": "https://geo.music.apple.com/us/album/tomorrow-will-be-better/1796481646?i=1796481647"
                 },
                 "spotify": {
                     "id": "3lGjhba2obegIC8Xc8VMK7"
@@ -8234,7 +8234,7 @@
                     "video_id": "rt_z10mb_k0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/house-tour/1836002188?i=1836002630"
+                    "url": "https://geo.music.apple.com/us/album/house-tour/1836002188?i=1836002630"
                 },
                 "spotify": {
                     "id": "25jgQBxuUkGDdCG1WGKKN9"
@@ -8260,7 +8260,7 @@
                     "video_id": "LC0lnWGnlwM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shiny/1817713947?i=1817714083"
+                    "url": "https://geo.music.apple.com/us/album/shiny/1817713947?i=1817714083"
                 },
                 "spotify": {
                     "id": "72aGCwuSwD5Qb3tHvXBoX3"
@@ -8286,7 +8286,7 @@
                     "video_id": "wZ2njttY3BA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/striptease/1851537222?i=1851537225"
+                    "url": "https://geo.music.apple.com/us/album/striptease/1851537222?i=1851537225"
                 },
                 "spotify": {
                     "id": "5kILHrfMHQ4eFHZqnu4yY3"
@@ -8311,7 +8311,7 @@
                     "video_id": "wR1YwNX8wdc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bigger-pieces/1790255063?i=1790255081"
+                    "url": "https://geo.music.apple.com/us/album/bigger-pieces/1790255063?i=1790255081"
                 },
                 "spotify": {
                     "id": "6oSMF3TrouX3TNO6NZbRhG"
@@ -8345,7 +8345,7 @@
                     "video_id": "RNlDqOYin8c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/we-were-just-here/1820903663?i=1820904033"
+                    "url": "https://geo.music.apple.com/us/album/we-were-just-here/1820903663?i=1820904033"
                 },
                 "spotify": {
                     "id": "7JfVH9o5zzVTKy5YcIYlfT"
@@ -8371,7 +8371,7 @@
                     "video_id": "a1Qyv4mBl5s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/no-good/1787417045?i=1787417052"
+                    "url": "https://geo.music.apple.com/us/album/no-good/1787417045?i=1787417052"
                 },
                 "spotify": {
                     "id": "5rO4yGfig3G1OeHWXf5uy5"
@@ -8397,7 +8397,7 @@
                     "video_id": "F8Kbk4_Vd4w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/canaan-land/1846590380?i=1846590381"
+                    "url": "https://geo.music.apple.com/us/album/canaan-land/1846590380?i=1846590381"
                 },
                 "spotify": {
                     "id": "54EUn24yXGAJ8AloharkT7"
@@ -8423,7 +8423,7 @@
                     "video_id": "1uFhxnN_bTY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pitstop-2024/1832560491?i=1832560753"
+                    "url": "https://geo.music.apple.com/us/album/pitstop-2024/1832560491?i=1832560753"
                 },
                 "spotify": {
                     "id": "7ocARHwG3dk089ujfdowzJ"
@@ -8454,7 +8454,7 @@
                     "video_id": "ViRzkfbicgI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/made-sum-plans/1792003831?i=1792003843"
+                    "url": "https://geo.music.apple.com/us/album/made-sum-plans/1792003831?i=1792003843"
                 },
                 "spotify": {
                     "id": "5sE9XpE2ukIwC2sYhIvUrs"
@@ -8480,7 +8480,7 @@
                     "video_id": "l66QEIfCE0Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/eatin-big-time/1818393806?i=1818393826"
+                    "url": "https://geo.music.apple.com/us/album/eatin-big-time/1818393806?i=1818393826"
                 },
                 "spotify": {
                     "id": "6b77gsnwtmE0mY1Xkv3Tyn"
@@ -8539,7 +8539,7 @@
                     "video_id": "oRogOHhyG1M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/long-island-city-here-i-come/1818548779?i=1818549171"
+                    "url": "https://geo.music.apple.com/us/album/long-island-city-here-i-come/1818548779?i=1818549171"
                 },
                 "spotify": {
                     "id": "1oevydxCBM8J6aGHKymgl1"
@@ -8570,7 +8570,7 @@
                     "video_id": "VHsJCGh4gr4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/worst-behaviour-feat-kehlani/1820237151?i=1820237155"
+                    "url": "https://geo.music.apple.com/us/album/worst-behaviour-feat-kehlani/1820237151?i=1820237155"
                 },
                 "spotify": {
                     "id": "5W67A7t9MWL3VtovrVrici"
@@ -8601,7 +8601,7 @@
                     "video_id": "7cEhNc-l6ME"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/b-a-d-i-d-e-a/1821959132?i=1821959135"
+                    "url": "https://geo.music.apple.com/us/album/b-a-d-i-d-e-a/1821959132?i=1821959135"
                 },
                 "spotify": {
                     "id": "5qDvHAFgbVJrGkBb7sJM07"
@@ -8629,7 +8629,7 @@
                     "video_id": "E8loFmVg20Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/miss/1810025525?i=1810025528"
+                    "url": "https://geo.music.apple.com/us/album/miss/1810025525?i=1810025528"
                 },
                 "spotify": {
                     "id": "3iewIkYTvvaicW8iysqxuU"
@@ -8660,7 +8660,7 @@
                     "video_id": "voKY6BIdnDM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/first-it-was-a-movie-then-it-was-a-book/1795086992?i=1795086997"
+                    "url": "https://geo.music.apple.com/us/album/first-it-was-a-movie-then-it-was-a-book/1795086992?i=1795086997"
                 },
                 "spotify": {
                     "id": "0CO8FICjkvVDekOcarbvIR"
@@ -8686,7 +8686,7 @@
                     "video_id": "RBzD7nCDitc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/naked/1821892439?i=1821892720"
+                    "url": "https://geo.music.apple.com/us/album/naked/1821892439?i=1821892720"
                 },
                 "spotify": {
                     "id": "3eLxZnelhb4GtTdbqeW78b"
@@ -8712,7 +8712,7 @@
                     "video_id": "3ctZ0MuCFuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mirtazapine/1825872787?i=1825872788"
+                    "url": "https://geo.music.apple.com/us/album/mirtazapine/1825872787?i=1825872788"
                 },
                 "spotify": {
                     "id": "2FFXU4b8sIsiLiTo6EWO19"
@@ -8738,7 +8738,7 @@
                     "video_id": "YsUk3AiWYz8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bite-the-hand/1840205480?i=1840205481"
+                    "url": "https://geo.music.apple.com/us/album/bite-the-hand/1840205480?i=1840205481"
                 },
                 "spotify": {
                     "id": "1XhuLzTH3GGF7wAyQDorZf"
@@ -8768,7 +8768,7 @@
                     "video_id": "jdiG43gqO1E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/for-the-cold-country/1783713554?i=1783713622"
+                    "url": "https://geo.music.apple.com/us/album/for-the-cold-country/1783713554?i=1783713622"
                 },
                 "spotify": {
                     "id": "5FGMhsO9YBSakTgNX2rhFj"
@@ -8804,7 +8804,7 @@
                     "video_id": "3xIh2j1Gq0s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ancient-light/1793391799?i=1793391802"
+                    "url": "https://geo.music.apple.com/us/album/ancient-light/1793391799?i=1793391802"
                 },
                 "spotify": {
                     "id": "7zW1oZZy5m8zpJZfRfwGKv"
@@ -8835,7 +8835,7 @@
                     "video_id": "6wiIvfrd69Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pour-the-henny/1837337842?i=1837338078"
+                    "url": "https://geo.music.apple.com/us/album/pour-the-henny/1837337842?i=1837338078"
                 },
                 "spotify": {
                     "id": "1Z1TErSXbCXjEJWKqcpf3V"
@@ -8883,7 +8883,7 @@
                     "video_id": "nBJRaflBDBg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gorgeous/1834042903?i=1834042908"
+                    "url": "https://geo.music.apple.com/us/album/gorgeous/1834042903?i=1834042908"
                 },
                 "spotify": {
                     "id": "5T0mnzMsyHtmWB7Kou51Ph"
@@ -8909,7 +8909,7 @@
                     "video_id": "r6-UCSjNp_Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/down-for-too-long/1821991897?i=1821991901"
+                    "url": "https://geo.music.apple.com/us/album/down-for-too-long/1821991897?i=1821991901"
                 },
                 "spotify": {
                     "id": "31XmjiAkFQmFxWJNbyTuQH"
@@ -8940,7 +8940,7 @@
                     "video_id": "CjnB56tSCQI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gabriela/1861635146?i=1861635152"
+                    "url": "https://geo.music.apple.com/us/album/gabriela/1861635146?i=1861635152"
                 },
                 "spotify": {
                     "id": "1xOqGUkyxGQRdCvGpvWKmL"
@@ -8971,7 +8971,7 @@
                     "video_id": "JSFG-IE8n_c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/like-jennie/1795979743?i=1795979745"
+                    "url": "https://geo.music.apple.com/us/album/like-jennie/1795979743?i=1795979745"
                 },
                 "spotify": {
                     "id": "0fK7ie6XwGxQTIkpFoWkd1"
@@ -9025,7 +9025,7 @@
                     "video_id": "H8XPg7qqYIg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ensalada/1824019687?i=1824019699"
+                    "url": "https://geo.music.apple.com/us/album/ensalada/1824019687?i=1824019699"
                 },
                 "spotify": {
                     "id": "06ZX08uRQDK02emdw9mN28"
@@ -9051,7 +9051,7 @@
                     "video_id": "kGCsxPiW3N8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mermaid/1804697823?i=1804697825"
+                    "url": "https://geo.music.apple.com/us/album/mermaid/1804697823?i=1804697825"
                 },
                 "spotify": {
                     "id": "16EwipmNxKwHngBBwu6s8V"
@@ -9101,7 +9101,7 @@
                     "video_id": "lyn3YAeSUgo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sickle-walk/1788987931?i=1788987939"
+                    "url": "https://geo.music.apple.com/us/album/sickle-walk/1788987931?i=1788987939"
                 },
                 "spotify": {
                     "id": "0xrF5God3TXbCml7bEnMBq"
@@ -9131,7 +9131,7 @@
                     "video_id": "ZapyHmmLnMQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/thief/1794880972?i=1794880973"
+                    "url": "https://geo.music.apple.com/us/album/thief/1794880972?i=1794880973"
                 },
                 "spotify": {
                     "id": "20kfSemlOU2CpCmh7GRSRv"
@@ -9162,7 +9162,7 @@
                     "video_id": "U_uVVO7eGic"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/infinite-source/1825435148?i=1825435153"
+                    "url": "https://geo.music.apple.com/us/album/infinite-source/1825435148?i=1825435153"
                 },
                 "spotify": {
                     "id": "3txlvthoUa9vWvG1zr2Lnr"
@@ -9193,7 +9193,7 @@
                     "video_id": "nS-fOh1CfhQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/no-broke-boys/1830260160?i=1830260717"
+                    "url": "https://geo.music.apple.com/us/album/no-broke-boys/1830260160?i=1830260717"
                 },
                 "spotify": {
                     "id": "3cZajhyr8LmtPfHZ9296tj"
@@ -9219,7 +9219,7 @@
                     "video_id": "TIS_PmDITA4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bloom-baby-bloom/1812904249?i=1812904788"
+                    "url": "https://geo.music.apple.com/us/album/bloom-baby-bloom/1812904249?i=1812904788"
                 },
                 "spotify": {
                     "id": "2piywRQIsqCM9cei6ZYTkl"
@@ -9244,7 +9244,7 @@
                     "video_id": "xR0wyxef05Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/imaginary-festival/1826121102?i=1826121107"
+                    "url": "https://geo.music.apple.com/us/album/imaginary-festival/1826121102?i=1826121107"
                 },
                 "spotify": {
                     "id": "2HTx5BWjcnsiq1ZDTSpAW7"
@@ -9273,7 +9273,7 @@
                     "video_id": "5XqCp7Z7fgg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/artificial-angels/1843964358?i=1843964359"
+                    "url": "https://geo.music.apple.com/us/album/artificial-angels/1843964358?i=1843964359"
                 },
                 "spotify": {
                     "id": "0cAFtuZPD4sKl0X1R3dFin"
@@ -9299,7 +9299,7 @@
                     "video_id": "BKdigb7GasY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/viscus/1836387501?i=1836387502"
+                    "url": "https://geo.music.apple.com/us/album/viscus/1836387501?i=1836387502"
                 },
                 "spotify": {
                     "id": "5ksAnx6NyYbHMQhEI7Y07B"
@@ -9325,7 +9325,7 @@
                     "video_id": "_3wk2V9us5s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/drinking-age/1766984761?i=1766985032"
+                    "url": "https://geo.music.apple.com/us/album/drinking-age/1766984761?i=1766985032"
                 },
                 "spotify": {
                     "id": "6nUPcVDYjCrnNMaXAJ9eO3"
@@ -9356,7 +9356,7 @@
                     "video_id": "OkjZtIXXAWo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/new-girl/1804709619?i=1804709621"
+                    "url": "https://geo.music.apple.com/us/album/new-girl/1804709619?i=1804709621"
                 },
                 "spotify": {
                     "id": "5Ha86zPip9CSUj8hB61yUi"
@@ -9387,7 +9387,7 @@
                     "video_id": "l6_bC6gV0zI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cosa-rara-feat-david-sylvian/1807404987?i=1807404988"
+                    "url": "https://geo.music.apple.com/us/album/cosa-rara-feat-david-sylvian/1807404987?i=1807404988"
                 },
                 "spotify": {
                     "id": "6CwycpWoVoUfZF5F7stEC2"
@@ -9417,7 +9417,7 @@
                     "video_id": "hWjwNgiLMgA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bmf/1794644675?i=1794644681"
+                    "url": "https://geo.music.apple.com/us/album/bmf/1794644675?i=1794644681"
                 },
                 "spotify": {
                     "id": "3U3hFkMr0Q90pD24EkE3Pr"
@@ -9443,7 +9443,7 @@
                     "video_id": "WKLLxAOeTPA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shy/1814463235?i=1814463252"
+                    "url": "https://geo.music.apple.com/us/album/shy/1814463235?i=1814463252"
                 },
                 "spotify": {
                     "id": "2N6md2JtrNake4sJ14KJ72"
@@ -9469,7 +9469,7 @@
                     "video_id": "S7GXhwYnF9w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/high-fashion/1809015416?i=1809015863"
+                    "url": "https://geo.music.apple.com/us/album/high-fashion/1809015416?i=1809015863"
                 },
                 "spotify": {
                     "id": "7KwPWmB1gA9zRubseJ7OB2"
@@ -9516,7 +9516,7 @@
                     "video_id": "BnT8oVP-umc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/elegy-for-noah-lou/1761198973?i=1761199168"
+                    "url": "https://geo.music.apple.com/us/album/elegy-for-noah-lou/1761198973?i=1761199168"
                 },
                 "spotify": {
                     "id": "5kCWzxtf36Zooj51yL66Bt"
@@ -9542,7 +9542,7 @@
                     "video_id": "sPqvt5D5RNE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/winona/1792077173?i=1792077185"
+                    "url": "https://geo.music.apple.com/us/album/winona/1792077173?i=1792077185"
                 },
                 "spotify": {
                     "id": "24RP8LdRXT4Om2NxZ0R7OS"
@@ -9568,7 +9568,7 @@
                     "video_id": "Zaqr3As-K_I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-iconoclast/1830987314?i=1830987318"
+                    "url": "https://geo.music.apple.com/us/album/the-iconoclast/1830987314?i=1830987318"
                 },
                 "spotify": {
                     "id": "1RDzKhuTUKoGZ0XVnnyyxQ"
@@ -9594,7 +9594,7 @@
                     "video_id": "lENt7-t8I-I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/f-k-my-computer/1808612272?i=1808612278"
+                    "url": "https://geo.music.apple.com/us/album/f-k-my-computer/1808612272?i=1808612278"
                 },
                 "spotify": {
                     "id": "5ZbztTcvj6QWWbeYsL4GTa"
@@ -9628,7 +9628,7 @@
                     "video_id": "w2BY6y_LX5s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/picture-window/1785246760?i=1785247071"
+                    "url": "https://geo.music.apple.com/us/album/picture-window/1785246760?i=1785247071"
                 },
                 "spotify": {
                     "id": "02olsPYJypEE0IyuaGS4K4"
@@ -9679,7 +9679,7 @@
             "list_count": 1,
             "media": {
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-h-t-feat-adam-sinclaire/1846857577?i=1846857580"
+                    "url": "https://geo.music.apple.com/us/album/i-h-t-feat-adam-sinclaire/1846857577?i=1846857580"
                 },
                 "spotify": {
                     "id": "7cVpZrMlixJSqkWyzPq30F"
@@ -9713,7 +9713,7 @@
                     "video_id": "ZU9BNJRuuGA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/starkilla/1821073090?i=1821073092"
+                    "url": "https://geo.music.apple.com/us/album/starkilla/1821073090?i=1821073092"
                 },
                 "spotify": {
                     "id": "3S1fiHR7CUe9Nqa8h4H0u4"
@@ -9744,7 +9744,7 @@
                     "video_id": "-p7B8EKRRNc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nice-shoes/1832602931?i=1832602932"
+                    "url": "https://geo.music.apple.com/us/album/nice-shoes/1832602931?i=1832602932"
                 },
                 "spotify": {
                     "id": "26RtX0MphIh9C7ZWJEogJL"
@@ -9775,7 +9775,7 @@
                     "video_id": "CnP9OKJgOb4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/do-it/1846415812?i=1846416259"
+                    "url": "https://geo.music.apple.com/us/album/do-it/1846415812?i=1846416259"
                 },
                 "spotify": {
                     "id": "5BDo6TzD8q0oNtqhhXU3nx"
@@ -9829,7 +9829,7 @@
                     "video_id": "H5mAMRgo1NI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/rein-me-in/1860400918?i=1860402703"
+                    "url": "https://geo.music.apple.com/us/album/rein-me-in/1860400918?i=1860402703"
                 },
                 "spotify": {
                     "id": "7MZHqgTVTnN6xZGYAcEEAf"
@@ -9855,7 +9855,7 @@
                     "video_id": "sXW6mc6aSJE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-cried-i-wept/1786260282?i=1786260624"
+                    "url": "https://geo.music.apple.com/us/album/i-cried-i-wept/1786260282?i=1786260624"
                 },
                 "spotify": {
                     "id": "3yhEwhpcoymynMjDbIzoTp"
@@ -9881,7 +9881,7 @@
                     "video_id": "IY1y56PP_cE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/returning-to-myself/1848218479?i=1848218481"
+                    "url": "https://geo.music.apple.com/us/album/returning-to-myself/1848218479?i=1848218481"
                 },
                 "spotify": {
                     "id": "7kw7I7P3MmYKfD4a4bf41l"
@@ -9907,7 +9907,7 @@
                     "video_id": "uvfDaZ4ZT80"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lo-que-le-pas%C3%B3-a-hawaii/1787022393?i=1787023918"
+                    "url": "https://geo.music.apple.com/us/album/lo-que-le-pas%C3%B3-a-hawaii/1787022393?i=1787023918"
                 },
                 "spotify": {
                     "id": "1Hg0e997pObvZ91w1FCPFk"
@@ -9933,7 +9933,7 @@
                     "video_id": "7uocCB9Nq68"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/just-another-one/1827307566?i=1827307573"
+                    "url": "https://geo.music.apple.com/us/album/just-another-one/1827307566?i=1827307573"
                 },
                 "spotify": {
                     "id": "0G6UcQICO9sXR7tDojtAIN"
@@ -9959,7 +9959,7 @@
                     "video_id": "C7dTyo7pd20"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/losing-hand/1799478212?i=1799478220"
+                    "url": "https://geo.music.apple.com/us/album/losing-hand/1799478212?i=1799478220"
                 },
                 "spotify": {
                     "id": "2fs1OUCklhRwQs1MYFJTPw"
@@ -9990,7 +9990,7 @@
                     "video_id": "5oDI05YTy-4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sex-and-the-city/1826574954?i=1826575422"
+                    "url": "https://geo.music.apple.com/us/album/sex-and-the-city/1826574954?i=1826575422"
                 },
                 "spotify": {
                     "id": "05e0Tkr6tpxbktIei9q8Mw"
@@ -10043,7 +10043,7 @@
                     "video_id": "tZUTzSojU7A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/angelus/1829793718?i=1829793845"
+                    "url": "https://geo.music.apple.com/us/album/angelus/1829793718?i=1829793845"
                 },
                 "spotify": {
                     "id": "1mgV4OpYXRWjwQKSamgwQx"
@@ -10076,7 +10076,7 @@
                     "video_id": "pa4B-iuTQ1k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/do-what-i-say/1820237151?i=1820237326"
+                    "url": "https://geo.music.apple.com/us/album/do-what-i-say/1820237151?i=1820237326"
                 },
                 "spotify": {
                     "id": "5P8zrJH6NhD2QRIscTSTcq"
@@ -10107,7 +10107,7 @@
                     "video_id": "bHOGfH3HDqM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/landgrab-feat-earl-sweatshirt/1852135431?i=1852135443"
+                    "url": "https://geo.music.apple.com/us/album/landgrab-feat-earl-sweatshirt/1852135431?i=1852135443"
                 },
                 "spotify": {
                     "id": "2NvfuuEvIYsfRHJKuzg09y"
@@ -10133,7 +10133,7 @@
                     "video_id": "KqJ_TSnb_ws"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jets/1810763423?i=1810763426"
+                    "url": "https://geo.music.apple.com/us/album/jets/1810763423?i=1810763426"
                 },
                 "spotify": {
                     "id": "5Uu9EdaapVI3CrVT6bWe9x"
@@ -10159,7 +10159,7 @@
                     "video_id": "fuEtuSNP08E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/build-the-habit/1795552460?i=1795552461"
+                    "url": "https://geo.music.apple.com/us/album/build-the-habit/1795552460?i=1795552461"
                 },
                 "spotify": {
                     "id": "6Zb2xidjoa6IKEcYLMa9qN"
@@ -10190,7 +10190,7 @@
                     "video_id": "kt64MDdjtR8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-birds-dont-sing/1862672249?i=1862672254"
+                    "url": "https://geo.music.apple.com/us/album/the-birds-dont-sing/1862672249?i=1862672254"
                 },
                 "spotify": {
                     "id": "6L3i4jdNnk0a9kMT3qIqTG"
@@ -10216,7 +10216,7 @@
                     "video_id": "JX2GkxNT-IQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/walk-of-fame-feat-brittany-howard/1839062794?i=1839063075"
+                    "url": "https://geo.music.apple.com/us/album/walk-of-fame-feat-brittany-howard/1839062794?i=1839063075"
                 },
                 "spotify": {
                     "id": "4EJjVfB2pQNn0ZFe1DgUOX"
@@ -10241,7 +10241,7 @@
                     "video_id": "1UI-ur4iNPA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sugarcane/1830413686?i=1830413936"
+                    "url": "https://geo.music.apple.com/us/album/sugarcane/1830413686?i=1830413936"
                 },
                 "spotify": {
                     "id": "6EU8H0Nvnob3P99vWMT8vh"
@@ -10299,7 +10299,7 @@
                     "video_id": "ZOvfcMzB6RA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/a-bugs-life/1820509805?i=1820510321"
+                    "url": "https://geo.music.apple.com/us/album/a-bugs-life/1820509805?i=1820510321"
                 },
                 "spotify": {
                     "id": "1D7qrNAEbZ0G4oR6YZTvFK"
@@ -10330,7 +10330,7 @@
                     "video_id": "BouNQ9lREyA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/crush-feat-jorja-smith/1799728348?i=1799728352"
+                    "url": "https://geo.music.apple.com/us/album/crush-feat-jorja-smith/1799728348?i=1799728352"
                 },
                 "spotify": {
                     "id": "3cqAMw4w9px9nAV6iROr0a"
@@ -10356,7 +10356,7 @@
                     "video_id": "qgFNCy6u4UQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/this-song/1816089441?i=1816089443"
+                    "url": "https://geo.music.apple.com/us/album/this-song/1816089441?i=1816089443"
                 },
                 "spotify": {
                     "id": "43awRzMhW0Dfcg6MrBBnw0"
@@ -10387,7 +10387,7 @@
                     "video_id": "tQHLIRCcfio"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/vanish-into-you/1837310866?i=1837310875"
+                    "url": "https://geo.music.apple.com/us/album/vanish-into-you/1837310866?i=1837310875"
                 },
                 "spotify": {
                     "id": "5IoPnNiYAOvHHJpz13wzRL"
@@ -10413,7 +10413,7 @@
                     "video_id": "o8bXjhf9TrU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/man-in-the-mirror/1788674268?i=1788674453"
+                    "url": "https://geo.music.apple.com/us/album/man-in-the-mirror/1788674268?i=1788674453"
                 },
                 "spotify": {
                     "id": "4KmNLSvaKU0zoJhIptn961"
@@ -10483,7 +10483,7 @@
                     "video_id": "Y03n19YRXD4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/messy/1802959214?i=1802959269"
+                    "url": "https://geo.music.apple.com/us/album/messy/1802959214?i=1802959269"
                 },
                 "spotify": {
                     "id": "35ISBknsCeZQtq66xABI9g"
@@ -10509,7 +10509,7 @@
                     "video_id": "BySWTFt1KcE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/scorsese-baby-daddy/1794644675?i=1794644683"
+                    "url": "https://geo.music.apple.com/us/album/scorsese-baby-daddy/1794644675?i=1794644683"
                 },
                 "spotify": {
                     "id": "2E7a96qey4AzSOdK6H21vS"
@@ -10535,7 +10535,7 @@
                     "video_id": "rov2Qglm804"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/livflare-broadway-market/1837562970?i=1837562971"
+                    "url": "https://geo.music.apple.com/us/album/livflare-broadway-market/1837562970?i=1837562971"
                 },
                 "spotify": {
                     "id": "5QrD3NhHGvHopwK8cbu6mS"
@@ -10561,7 +10561,7 @@
                     "video_id": "9t8QPdaVe8U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/comafields/1826121102?i=1826121105"
+                    "url": "https://geo.music.apple.com/us/album/comafields/1826121102?i=1826121105"
                 },
                 "spotify": {
                     "id": "1fZVOJkqVsjbh7TbRCcVlo"
@@ -10587,7 +10587,7 @@
                     "video_id": "9Rk2tuhNaoU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/opm-babi/1802175271?i=1802175744"
+                    "url": "https://geo.music.apple.com/us/album/opm-babi/1802175271?i=1802175744"
                 },
                 "spotify": {
                     "id": "76yJsfb1CUy5Um8nFL7jKQ"
@@ -10618,7 +10618,7 @@
                     "video_id": "yNszjqIDsIU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dime/1824504862?i=1824505223"
+                    "url": "https://geo.music.apple.com/us/album/dime/1824504862?i=1824505223"
                 },
                 "spotify": {
                     "id": "5hGnVYPjDs12ARhRjAzxCQ"
@@ -10649,7 +10649,7 @@
                     "video_id": "jrLxBCaM66I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/blk-xmas-feat-bruiser-wolf-sadhugold/1793411266?i=1793411996"
+                    "url": "https://geo.music.apple.com/us/album/blk-xmas-feat-bruiser-wolf-sadhugold/1793411266?i=1793411996"
                 },
                 "spotify": {
                     "id": "5CGpW9rlmnHPItIB69SZyC"
@@ -10698,7 +10698,7 @@
                     "video_id": "RYRQ7d8RF1M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bring-bac-act-feat-rio-da-yung-og/1804213283?i=1804213284"
+                    "url": "https://geo.music.apple.com/us/album/bring-bac-act-feat-rio-da-yung-og/1804213283?i=1804213284"
                 },
                 "spotify": {
                     "id": "2ErulGehAyGFfyB9N4HDHP"
@@ -10723,7 +10723,7 @@
                     "video_id": "5GSLYaasBvw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/slapped-by-my-life/1838520668?i=1838520673"
+                    "url": "https://geo.music.apple.com/us/album/slapped-by-my-life/1838520668?i=1838520673"
                 },
                 "spotify": {
                     "id": "6TkqnafmCsB2JavcMkFuwE"
@@ -10749,7 +10749,7 @@
                     "video_id": "Bkv-Qn1XM7o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shapeshifter/1810905299?i=1810905308"
+                    "url": "https://geo.music.apple.com/us/album/shapeshifter/1810905299?i=1810905308"
                 },
                 "spotify": {
                     "id": "0vtgMfyOVM2Y97DcVVJw3m"
@@ -10775,7 +10775,7 @@
                     "video_id": "l4aV4Pg4bJ0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/love-pop-feat-chanel-beads/1828913315?i=1828913322"
+                    "url": "https://geo.music.apple.com/us/album/love-pop-feat-chanel-beads/1828913315?i=1828913322"
                 },
                 "spotify": {
                     "id": "657y4ybpQX9jyGLRKgNalz"
@@ -10805,7 +10805,7 @@
                     "video_id": "0NY1Pwu9N5A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jerskin-fendrix-freestyle/1801947251?i=1801947252"
+                    "url": "https://geo.music.apple.com/us/album/jerskin-fendrix-freestyle/1801947251?i=1801947252"
                 },
                 "spotify": {
                     "id": "3jbL2rMON1hyDCaU4QQTbe"
@@ -10830,7 +10830,7 @@
                     "video_id": "kwUY4d_pMZs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/woman-lake/1827338632?i=1827339127"
+                    "url": "https://geo.music.apple.com/us/album/woman-lake/1827338632?i=1827339127"
                 },
                 "spotify": {
                     "id": "13jIYWdJqaXqON3URRS6Q3"
@@ -10856,7 +10856,7 @@
                     "video_id": "2tzrJPQD71s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/june-guitar/1815825254?i=1815825255"
+                    "url": "https://geo.music.apple.com/us/album/june-guitar/1815825254?i=1815825255"
                 },
                 "spotify": {
                     "id": "1leMmYw98725djni7wSYhq"
@@ -10882,7 +10882,7 @@
                     "video_id": "6bk2P9HI1zQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pretty-petty/1850666044?i=1850666050"
+                    "url": "https://geo.music.apple.com/us/album/pretty-petty/1850666044?i=1850666050"
                 },
                 "spotify": {
                     "id": "2wn0AYkmcF0Cm7PmvA7hJ7"
@@ -10908,7 +10908,7 @@
                     "video_id": "bn8gP5N8hqM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cry-for-me/1793654348?i=1793654350"
+                    "url": "https://geo.music.apple.com/us/album/cry-for-me/1793654348?i=1793654350"
                 },
                 "spotify": {
                     "id": "3AWDeHLc88XogCaCnZQLVI"
@@ -10938,7 +10938,7 @@
                     "video_id": "wQ-jTdRPA48"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gold-rush/1790502494?i=1790502656"
+                    "url": "https://geo.music.apple.com/us/album/gold-rush/1790502494?i=1790502656"
                 },
                 "spotify": {
                     "id": "5Mt9Jy5q3Z0DaDxRcZMVOQ"
@@ -10964,7 +10964,7 @@
                     "video_id": "baP0EACGGXI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/27a-pitfield-st/1846006072?i=1846006074"
+                    "url": "https://geo.music.apple.com/us/album/27a-pitfield-st/1846006072?i=1846006074"
                 },
                 "spotify": {
                     "id": "53uhTsdGotEgrDAJydRSov"
@@ -10990,7 +10990,7 @@
                     "video_id": "hti_yozy6Zk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tree-of-heaven/1839208122?i=1839208126"
+                    "url": "https://geo.music.apple.com/us/album/tree-of-heaven/1839208122?i=1839208126"
                 },
                 "spotify": {
                     "id": "2xwIdafNS0XTIpKYNKkU82"
@@ -11019,7 +11019,7 @@
                     "video_id": "6G3KZJXoybM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/back-in-the-game/1781311112?i=1781311189"
+                    "url": "https://geo.music.apple.com/us/album/back-in-the-game/1781311112?i=1781311189"
                 },
                 "spotify": {
                     "id": "36MzQtHbBHdefK2que90MO"
@@ -11067,7 +11067,7 @@
                     "video_id": "lIWFsWPCzLA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oh-canada/1838923788?i=1838923792"
+                    "url": "https://geo.music.apple.com/us/album/oh-canada/1838923788?i=1838923792"
                 },
                 "spotify": {
                     "id": "6o9RVwLINAd1COHkmv0TZd"
@@ -11093,7 +11093,7 @@
                     "video_id": "yiEmRp99FPQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dissolved/1811840755?i=1811840763"
+                    "url": "https://geo.music.apple.com/us/album/dissolved/1811840755?i=1811840763"
                 },
                 "spotify": {
                     "id": "2UaTUbuCaQOdWk0q0bDRYl"
@@ -11119,7 +11119,7 @@
                     "video_id": "MsZhYgo9MoA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/baby-is-it-a-crime/1835458110?i=1835459074"
+                    "url": "https://geo.music.apple.com/us/album/baby-is-it-a-crime/1835458110?i=1835459074"
                 },
                 "spotify": {
                     "id": "6NOrpcicPUh2eaj8bAD44u"
@@ -11145,7 +11145,7 @@
                     "video_id": "PsQ2KuKPyVM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sk8/1832251919?i=1832251928"
+                    "url": "https://geo.music.apple.com/us/album/sk8/1832251919?i=1832251928"
                 },
                 "spotify": {
                     "id": "0gTzUSGlZvhrSz72OnBijn"
@@ -11171,7 +11171,7 @@
                     "video_id": "bYUObXSWYc8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mr-media/1828461329?i=1828461343"
+                    "url": "https://geo.music.apple.com/us/album/mr-media/1828461329?i=1828461343"
                 },
                 "spotify": {
                     "id": "1EUCFwyhBlHxGVKlqe6Dw7"
@@ -11196,7 +11196,7 @@
                     "video_id": "6I_YVt3lUzM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/run/1817666527?i=1817666528"
+                    "url": "https://geo.music.apple.com/us/album/run/1817666527?i=1817666528"
                 },
                 "spotify": {
                     "id": "29YCXYGQo3YU7lx3g2EgLI"
@@ -11222,7 +11222,7 @@
                     "video_id": "EOPNV4oD9ho"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/inferno/1840465860?i=1840465869"
+                    "url": "https://geo.music.apple.com/us/album/inferno/1840465860?i=1840465869"
                 },
                 "spotify": {
                     "id": "31O8ZZCnYkHonBL00glsTT"
@@ -11248,7 +11248,7 @@
                     "video_id": "8YrElTX3pfA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/can-we-talk-about-isaac/1806334073?i=1806334416"
+                    "url": "https://geo.music.apple.com/us/album/can-we-talk-about-isaac/1806334073?i=1806334416"
                 },
                 "spotify": {
                     "id": "1SsyXtMR9nDhGCqJeWPB0r"
@@ -11274,7 +11274,7 @@
                     "video_id": "u7jxMExs7_I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tell-me/1822752829?i=1822752844"
+                    "url": "https://geo.music.apple.com/us/album/tell-me/1822752829?i=1822752844"
                 },
                 "spotify": {
                     "id": "3wE1c11pDVYtMKb0lgqGdN"
@@ -11300,7 +11300,7 @@
                     "video_id": "Mso9hxqnZgk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-could/1805818808?i=1805818815"
+                    "url": "https://geo.music.apple.com/us/album/i-could/1805818808?i=1805818815"
                 },
                 "spotify": {
                     "id": "5EmtveGyjsE023P8atahBQ"
@@ -11329,7 +11329,7 @@
                     "video_id": "zlngRbI9bpw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-boy/1824330589?i=1824330594"
+                    "url": "https://geo.music.apple.com/us/album/the-boy/1824330589?i=1824330594"
                 },
                 "spotify": {
                     "id": "71opuLWkFhYlqcYYKPkkQw"
@@ -11362,7 +11362,7 @@
                     "video_id": "X7eYsZrJmqI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/demolition/1775442492?i=1775442977"
+                    "url": "https://geo.music.apple.com/us/album/demolition/1775442492?i=1775442977"
                 },
                 "spotify": {
                     "id": "68Y9Fv5hpOeRRLVItcWAd0"
@@ -11388,7 +11388,7 @@
                     "video_id": "Ad7eDEAy1Es"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/have-a-nice-dream-sweetheart/1789594196?i=1789594197"
+                    "url": "https://geo.music.apple.com/us/album/have-a-nice-dream-sweetheart/1789594196?i=1789594197"
                 },
                 "spotify": {
                     "id": "0uq0OrFNaOhCDOlySbYTUx"
@@ -11413,7 +11413,7 @@
                     "video_id": "b1EsWeSlhmA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/waterproof-mascara-feat-preservation/1793411266?i=1793411999"
+                    "url": "https://geo.music.apple.com/us/album/waterproof-mascara-feat-preservation/1793411266?i=1793411999"
                 },
                 "spotify": {
                     "id": "7oSiIeLokeBcz55p8fT352"
@@ -11439,7 +11439,7 @@
                     "video_id": "4BQZ-YgVGsk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/my-world/1811873626?i=1811873909"
+                    "url": "https://geo.music.apple.com/us/album/my-world/1811873626?i=1811873909"
                 },
                 "spotify": {
                     "id": "5PCn4ysnzhILLhQY0u4Ans"
@@ -11465,7 +11465,7 @@
                     "video_id": "8la0W5wYMkY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/current-affairs/1810905299?i=1810905315"
+                    "url": "https://geo.music.apple.com/us/album/current-affairs/1810905299?i=1810905315"
                 },
                 "spotify": {
                     "id": "1cQQB9z7fNQQ2VzSkslt7Y"
@@ -11491,7 +11491,7 @@
                     "video_id": "c7_s1vaBycs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cross-passage/1829400901?i=1829400902"
+                    "url": "https://geo.music.apple.com/us/album/cross-passage/1829400901?i=1829400902"
                 },
                 "spotify": {
                     "id": "1pgOxuh7detTTpsURRAHjX"
@@ -11517,7 +11517,7 @@
                     "video_id": "-83-kPTNplQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/garbage-dream-house/1807902930?i=1807902936"
+                    "url": "https://geo.music.apple.com/us/album/garbage-dream-house/1807902930?i=1807902936"
                 },
                 "spotify": {
                     "id": "76cifUIaquJRo1utBIenpZ"
@@ -11543,7 +11543,7 @@
                     "video_id": "GULLIAZmmQA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/chicago-four/1833028209?i=1833028211"
+                    "url": "https://geo.music.apple.com/us/album/chicago-four/1833028209?i=1833028211"
                 },
                 "spotify": {
                     "id": "4nvzhSt4cQ727P3zkRV2oc"
@@ -11569,7 +11569,7 @@
                     "video_id": "L-14HNoSrV4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ill-take-it/1791204138?i=1791204480"
+                    "url": "https://geo.music.apple.com/us/album/ill-take-it/1791204138?i=1791204480"
                 },
                 "spotify": {
                     "id": "0FAlG6uOeaXWuRdDxaeIQY"
@@ -11595,7 +11595,7 @@
                     "video_id": "T6Q3hIqtrDo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/7-stars/1821757932?i=1821757933"
+                    "url": "https://geo.music.apple.com/us/album/7-stars/1821757932?i=1821757933"
                 },
                 "spotify": {
                     "id": "0XUiXuJ817oHMeqM3W3KWi"
@@ -11648,7 +11648,7 @@
                     "video_id": "Nk-WOiE61KM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ladida/1824330589?i=1824330592"
+                    "url": "https://geo.music.apple.com/us/album/ladida/1824330589?i=1824330592"
                 },
                 "spotify": {
                     "id": "53v5RuuAux3F8anCHDNwXI"
@@ -11673,7 +11673,7 @@
                     "video_id": "SZJrNmCYWCM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/yeah-i-like-ah/1791111635?i=1791111833"
+                    "url": "https://geo.music.apple.com/us/album/yeah-i-like-ah/1791111635?i=1791111833"
                 },
                 "spotify": {
                     "id": "2hnLGF7CvK1ACEXVNRNkDi"
@@ -11699,7 +11699,7 @@
                     "video_id": "RLcKe6DcIUM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/magnet/1850411591?i=1850412469"
+                    "url": "https://geo.music.apple.com/us/album/magnet/1850411591?i=1850412469"
                 },
                 "spotify": {
                     "id": "7dHblXsJTRemgyIvFNJE7t"
@@ -11729,7 +11729,7 @@
                     "video_id": "7yD2r4DIrLc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/radioactive-dreams/1829444582?i=1829444622"
+                    "url": "https://geo.music.apple.com/us/album/radioactive-dreams/1829444582?i=1829444622"
                 },
                 "spotify": {
                     "id": "5CyZ9a2GwSyDOcOw37bo6J"
@@ -11758,7 +11758,7 @@
                     "video_id": "r_YQ_G_e2Ps"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/get-to-choose/1846456194?i=1846456702"
+                    "url": "https://geo.music.apple.com/us/album/get-to-choose/1846456194?i=1846456702"
                 },
                 "spotify": {
                     "id": "5h9FYRmddlb1x0ybleGPxY"
@@ -11810,7 +11810,7 @@
                     "video_id": "7Osgb4A5wsE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pharmacy-feat-ivy-knight/1801099411?i=1801099729"
+                    "url": "https://geo.music.apple.com/us/album/pharmacy-feat-ivy-knight/1801099411?i=1801099729"
                 },
                 "spotify": {
                     "id": "5dAM0dvquAo2Oha9i1J8jb"
@@ -11836,7 +11836,7 @@
                     "video_id": "29ToiaUotCE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/blakk-rokkstar/1806780313?i=1806780653"
+                    "url": "https://geo.music.apple.com/us/album/blakk-rokkstar/1806780313?i=1806780653"
                 },
                 "spotify": {
                     "id": "1LsisG6aoqfsF1r6M4LpMO"
@@ -11862,7 +11862,7 @@
                     "video_id": "QoTGRO3pMnY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/they/1802606063?i=1802606529"
+                    "url": "https://geo.music.apple.com/us/album/they/1802606063?i=1802606529"
                 },
                 "spotify": {
                     "id": "3lBRPvbrZQKI8EOXBNYdNO"
@@ -11888,7 +11888,7 @@
                     "video_id": "QlA30n9d_vo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pretrial-let-her-go-home/1812099583?i=1812099897"
+                    "url": "https://geo.music.apple.com/us/album/pretrial-let-her-go-home/1812099583?i=1812099897"
                 },
                 "spotify": {
                     "id": "7sGQ4jAOUs3YG1CFyjDxdc"
@@ -11914,7 +11914,7 @@
                     "video_id": "HTegnDQauFo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/undertow-vince-clarke-remix/1809101693?i=1809101994"
+                    "url": "https://geo.music.apple.com/us/album/undertow-vince-clarke-remix/1809101693?i=1809101994"
                 },
                 "spotify": {
                     "id": "24kIbzb70Cc8GX09mC6k4U"
@@ -11940,7 +11940,7 @@
                     "video_id": "MQZ1H7rTbF4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/see-feat-sophia-al-maria-ben-vince/1806085943?i=1806085947"
+                    "url": "https://geo.music.apple.com/us/album/see-feat-sophia-al-maria-ben-vince/1806085943?i=1806085947"
                 },
                 "spotify": {
                     "id": "3ezTBOGeNUNpx4h8ToEl4O"
@@ -11966,7 +11966,7 @@
                     "video_id": "A5kZ4h_hjDU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/baby/1849765058?i=1849765066"
+                    "url": "https://geo.music.apple.com/us/album/baby/1849765058?i=1849765066"
                 },
                 "spotify": {
                     "id": "5Oq6iKIWE3Q1i3G2fES5Oc"
@@ -11991,7 +11991,7 @@
                     "video_id": "3q8oSGTd0U4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wolf-in-sheeps-clothes/1792022220?i=1792022222"
+                    "url": "https://geo.music.apple.com/us/album/wolf-in-sheeps-clothes/1792022220?i=1792022222"
                 },
                 "spotify": {
                     "id": "7oUiQH66dtqxiUuRgrRrz6"
@@ -12022,7 +12022,7 @@
                     "video_id": "xtRVa4kOBt4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ipod-touch/1817553615?i=1817553617"
+                    "url": "https://geo.music.apple.com/us/album/ipod-touch/1817553615?i=1817553617"
                 },
                 "spotify": {
                     "id": "1xqT27jSG1Y15vOXfsV0gv"
@@ -12048,7 +12048,7 @@
                     "video_id": "gzaJfoiMVAE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/girls-gone-wild/1846531156?i=1846531643"
+                    "url": "https://geo.music.apple.com/us/album/girls-gone-wild/1846531156?i=1846531643"
                 },
                 "spotify": {
                     "id": "1TYLYTMtSIqqPpOGJhmp0y"
@@ -12079,7 +12079,7 @@
                     "video_id": "xYJJWc3HUQc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dead/1820509805?i=1820509806"
+                    "url": "https://geo.music.apple.com/us/album/dead/1820509805?i=1820509806"
                 },
                 "spotify": {
                     "id": "1MRQ49rkgqahm7K51ZjtRf"
@@ -12105,7 +12105,7 @@
                     "video_id": "1QvBWEJCQ4w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/now-2/1796957164?i=1796957172"
+                    "url": "https://geo.music.apple.com/us/album/now-2/1796957164?i=1796957172"
                 },
                 "spotify": {
                     "id": "5WtSUNzsF6LM46V1S1D32s"
@@ -12130,7 +12130,7 @@
                     "video_id": "Aizpvina1Fs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/less-is-more/1806047090?i=1806047113"
+                    "url": "https://geo.music.apple.com/us/album/less-is-more/1806047090?i=1806047113"
                 },
                 "spotify": {
                     "id": "6CZKeP30SneJmRQpYxLCYZ"
@@ -12175,7 +12175,7 @@
                     "video_id": "RTqx2p_c7a8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/it-was-like-you-were-coming-to-wake-us-back-up/1786241717?i=1786242035"
+                    "url": "https://geo.music.apple.com/us/album/it-was-like-you-were-coming-to-wake-us-back-up/1786241717?i=1786242035"
                 },
                 "spotify": {
                     "id": "2aQIBBFWfv5zlCjovi1u5a"
@@ -12201,7 +12201,7 @@
                     "video_id": "LeG3jPeeMec"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/snow-white/1810514672?i=1810514842"
+                    "url": "https://geo.music.apple.com/us/album/snow-white/1810514672?i=1810514842"
                 },
                 "spotify": {
                     "id": "1AZwVoUx3UF5JbkUeMSUGe"
@@ -12227,7 +12227,7 @@
                     "video_id": "5OFLFVC11Cg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/end-of-you/1837050617?i=1837050620"
+                    "url": "https://geo.music.apple.com/us/album/end-of-you/1837050617?i=1837050620"
                 },
                 "spotify": {
                     "id": "0PsFsv5xUyX06ZhIEtFkeA"
@@ -12253,7 +12253,7 @@
                     "video_id": "4OPxNY5HMdo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-boy-who-played-the-harp/1847992481?i=1847992617"
+                    "url": "https://geo.music.apple.com/us/album/the-boy-who-played-the-harp/1847992481?i=1847992617"
                 },
                 "spotify": {
                     "id": "3qpbRVi19oJw1jMRSaNFPN"
@@ -12279,7 +12279,7 @@
                     "video_id": "txrSKpuSKgM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bromance/1808537941?i=1808537944"
+                    "url": "https://geo.music.apple.com/us/album/bromance/1808537941?i=1808537944"
                 },
                 "spotify": {
                     "id": "7E57zDS9CWw46fOwKDGEm0"
@@ -12305,7 +12305,7 @@
                     "video_id": "vRJKxTx62xk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pretend-youre-god/1839062794?i=1839063076"
+                    "url": "https://geo.music.apple.com/us/album/pretend-youre-god/1839062794?i=1839063076"
                 },
                 "spotify": {
                     "id": "0D7ptTqe5bFfHPn2PWJWoC"
@@ -12330,7 +12330,7 @@
                     "video_id": "6O-6speXYhM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/caught-by-a-wind-bff-remix/1807555445?i=1807555601"
+                    "url": "https://geo.music.apple.com/us/album/caught-by-a-wind-bff-remix/1807555445?i=1807555601"
                 },
                 "spotify": {
                     "id": "2Kal87D1p0qVj7ZKsUsl2T"
@@ -12356,7 +12356,7 @@
                     "video_id": "-rVK3vOFeYs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/port-pelegr%C3%AD/1804329771?i=1804330150"
+                    "url": "https://geo.music.apple.com/us/album/port-pelegr%C3%AD/1804329771?i=1804330150"
                 },
                 "spotify": {
                     "id": "22hH0aVWmxNW3clG1Dck8F"
@@ -12387,7 +12387,7 @@
                     "video_id": "pTcheoCpNuo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/david/1810905299?i=1810905894"
+                    "url": "https://geo.music.apple.com/us/album/david/1810905299?i=1810905894"
                 },
                 "spotify": {
                     "id": "6ghDayhHeBXAP4OOnnrFW9"
@@ -12413,7 +12413,7 @@
                     "video_id": "AOEklH8Eyw4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mature/1855831569?i=1855832140"
+                    "url": "https://geo.music.apple.com/us/album/mature/1855831569?i=1855832140"
                 },
                 "spotify": {
                     "id": "1BeyjPUWYbHcthHjusrejv"
@@ -12439,7 +12439,7 @@
                     "video_id": "62bivbrimHE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/so-hard/1826537047?i=1826537053"
+                    "url": "https://geo.music.apple.com/us/album/so-hard/1826537047?i=1826537053"
                 },
                 "spotify": {
                     "id": "1MkSNJ5s4yvdOoeB9DQqGP"
@@ -12465,7 +12465,7 @@
                     "video_id": "VQWBoMlD-dE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/theres-nothing-happening-between-us/1797780933?i=1797781430"
+                    "url": "https://geo.music.apple.com/us/album/theres-nothing-happening-between-us/1797780933?i=1797781430"
                 },
                 "spotify": {
                     "id": "0fOF5w2AEpkAnWL4AkBiO5"
@@ -12496,7 +12496,7 @@
                     "video_id": "8j3xtd78Lxw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/kissing-in-public/1805274232?i=1805274235"
+                    "url": "https://geo.music.apple.com/us/album/kissing-in-public/1805274232?i=1805274235"
                 },
                 "spotify": {
                     "id": "6sJR82bgpwFPjzB1DHzGw8"
@@ -12522,7 +12522,7 @@
                     "video_id": "iDuvxVgAD64"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/get-dumber-feat-jeff-rosenstock/1792971187?i=1792971607"
+                    "url": "https://geo.music.apple.com/us/album/get-dumber-feat-jeff-rosenstock/1792971187?i=1792971607"
                 },
                 "spotify": {
                     "id": "21Oh412OvkEtnqkYhrtLE2"
@@ -12547,7 +12547,7 @@
                     "video_id": "IgwH36h67hY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/angel-candles/1816036500?i=1816036502"
+                    "url": "https://geo.music.apple.com/us/album/angel-candles/1816036500?i=1816036502"
                 },
                 "spotify": {
                     "id": "7cl1kr7pqaXdDov0lf6cQq"
@@ -12573,7 +12573,7 @@
                     "video_id": "cu4--ehajz0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/unconditional/1853804711?i=1853805018"
+                    "url": "https://geo.music.apple.com/us/album/unconditional/1853804711?i=1853805018"
                 },
                 "spotify": {
                     "id": "394f1gySTJHUskHFpTxTW9"
@@ -12603,7 +12603,7 @@
                     "video_id": "WZkgxyzaMyo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/if-only-i-could-wait-feat-danielle-haim/1791161215?i=1791161563"
+                    "url": "https://geo.music.apple.com/us/album/if-only-i-could-wait-feat-danielle-haim/1791161215?i=1791161563"
                 },
                 "spotify": {
                     "id": "06o2hgwnRJN0HYelhyVsLm"
@@ -12629,7 +12629,7 @@
                     "video_id": "Agl_ks1BYHY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/battlefield-10th-anniversary-edition/1830363601?i=1830363602"
+                    "url": "https://geo.music.apple.com/us/album/battlefield-10th-anniversary-edition/1830363601?i=1830363602"
                 },
                 "spotify": {
                     "id": "5gqNyUJ8eJGzDByrB4cS7s"
@@ -12655,7 +12655,7 @@
                     "video_id": "Qi2squ2OaVE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nevermine/1819581569?i=1819581855"
+                    "url": "https://geo.music.apple.com/us/album/nevermine/1819581569?i=1819581855"
                 },
                 "spotify": {
                     "id": "2t3v2HTN5Rc8QMWJOPO847"
@@ -12681,7 +12681,7 @@
                     "video_id": "0_KGch347UI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/feisty/1802661282?i=1802661543"
+                    "url": "https://geo.music.apple.com/us/album/feisty/1802661282?i=1802661543"
                 },
                 "spotify": {
                     "id": "7Laa4tXNvO1QC63Qac53Gp"
@@ -12709,7 +12709,7 @@
                     "video_id": "sF2voRna8a0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-rust-belt/1798945935?i=1798945937"
+                    "url": "https://geo.music.apple.com/us/album/the-rust-belt/1798945935?i=1798945937"
                 },
                 "spotify": {
                     "id": "4ZaJZcd7lSFswJ8qBiF5yZ"
@@ -12735,7 +12735,7 @@
                     "video_id": "uNUH_v2PSWM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/second-sleep/1840286587?i=1840286591"
+                    "url": "https://geo.music.apple.com/us/album/second-sleep/1840286587?i=1840286591"
                 },
                 "spotify": {
                     "id": "47N21fn8V8IN392MGlicT5"
@@ -12761,7 +12761,7 @@
                     "video_id": "F564xVVJNiE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/errtime/1848192456?i=1848192783"
+                    "url": "https://geo.music.apple.com/us/album/errtime/1848192456?i=1848192783"
                 },
                 "spotify": {
                     "id": "2cBtsB7Pi89q9yWk59a2sX"
@@ -12787,7 +12787,7 @@
                     "video_id": "htToA3wcFl4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/somebody-loves-me/1796127242?i=1796127378"
+                    "url": "https://geo.music.apple.com/us/album/somebody-loves-me/1796127242?i=1796127378"
                 },
                 "spotify": {
                     "id": "2kZoOj1n5vk9BuF0sih58M"
@@ -12812,7 +12812,7 @@
                     "video_id": "mhYcpxcWQp0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/idol-time/1799802770?i=1799802774"
+                    "url": "https://geo.music.apple.com/us/album/idol-time/1799802770?i=1799802774"
                 },
                 "spotify": {
                     "id": "6CfIuRhcPnq0JmRmGlCv7a"
@@ -12841,7 +12841,7 @@
                     "video_id": "BDwPwvQ7DDY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-runner/1818183125?i=1818183129"
+                    "url": "https://geo.music.apple.com/us/album/the-runner/1818183125?i=1818183129"
                 },
                 "spotify": {
                     "id": "2Bn55HuKt3EhQ4AdBGKNAn"
@@ -12867,7 +12867,7 @@
                     "video_id": "UOIMVXqADQE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/three-foxes-chasing-each-other/1798265319?i=1798265907"
+                    "url": "https://geo.music.apple.com/us/album/three-foxes-chasing-each-other/1798265319?i=1798265907"
                 },
                 "spotify": {
                     "id": "0fSkyMme1Ze8ewpcbsiuIs"
@@ -12898,7 +12898,7 @@
                     "video_id": "qARrn7G067w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/laho-ii/1853065192?i=1853065218"
+                    "url": "https://geo.music.apple.com/us/album/laho-ii/1853065192?i=1853065218"
                 },
                 "spotify": {
                     "id": "4DREBgUie15tAPq9KQqe2c"
@@ -12929,7 +12929,7 @@
                     "video_id": "DZvV5ejmDVo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/besties/1783713554?i=1783713555"
+                    "url": "https://geo.music.apple.com/us/album/besties/1783713554?i=1783713555"
                 },
                 "spotify": {
                     "id": "4U9ZjqhaGF9wl56899E4sW"
@@ -12955,7 +12955,7 @@
                     "video_id": "75RB0cj3zOY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bout-u/1816030211?i=1816030693"
+                    "url": "https://geo.music.apple.com/us/album/bout-u/1816030211?i=1816030693"
                 },
                 "spotify": {
                     "id": "3qS4spuVywoeh9uGIpRuQh"
@@ -12981,7 +12981,7 @@
                     "video_id": "tuRIUuW-X4A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/miss/1853847178?i=1853848178"
+                    "url": "https://geo.music.apple.com/us/album/miss/1853847178?i=1853848178"
                 },
                 "spotify": {
                     "id": "7vBOMoBKb6InbMdQiFwRCO"
@@ -13007,7 +13007,7 @@
                     "video_id": "3djwrJgEmiA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dust-bowl/1818431571?i=1818431858"
+                    "url": "https://geo.music.apple.com/us/album/dust-bowl/1818431571?i=1818431858"
                 },
                 "spotify": {
                     "id": "7aamc4vRYmHLYI2aKTDjdJ"
@@ -13033,7 +13033,7 @@
                     "video_id": "jgPj14GtKJc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/putting-ya-dine/1834970891?i=1834970893"
+                    "url": "https://geo.music.apple.com/us/album/putting-ya-dine/1834970891?i=1834970893"
                 },
                 "spotify": {
                     "id": "3C9H7htrTDVHrP8BiB2f2r"
@@ -13059,7 +13059,7 @@
                     "video_id": "WNcFERh0KEE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/carried-away/1810920290?i=1810920298"
+                    "url": "https://geo.music.apple.com/us/album/carried-away/1810920290?i=1810920298"
                 },
                 "spotify": {
                     "id": "50ASFow3YrVJJpqdzaM1YD"
@@ -13085,7 +13085,7 @@
                     "video_id": "0E1cd5zbwAk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/my-unnies-feat-sebii-the-deep-effie/1831761197?i=1831761354"
+                    "url": "https://geo.music.apple.com/us/album/my-unnies-feat-sebii-the-deep-effie/1831761197?i=1831761354"
                 },
                 "spotify": {
                     "id": "42T8sQmsrdEuEFqDAHrhSz"
@@ -13111,7 +13111,7 @@
                     "video_id": "QS1zEVgXgTo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/a-few-songs-feat-love-mansuy-ogi-smino/1792985706?i=1792986588"
+                    "url": "https://geo.music.apple.com/us/album/a-few-songs-feat-love-mansuy-ogi-smino/1792985706?i=1792986588"
                 },
                 "spotify": {
                     "id": "7K9DMSR7ZlN1aAzJas8220"
@@ -13137,7 +13137,7 @@
                     "video_id": "qq8QGP1n600"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/is-it-worth-it-happy-birthday/1814969020?i=1814969330"
+                    "url": "https://geo.music.apple.com/us/album/is-it-worth-it-happy-birthday/1814969020?i=1814969330"
                 },
                 "spotify": {
                     "id": "2g5S7Pf6SIHzdw47muIDw9"
@@ -13163,7 +13163,7 @@
                     "video_id": "dBVmXVX09Ak"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/three-six-five/1794408739?i=1794408745"
+                    "url": "https://geo.music.apple.com/us/album/three-six-five/1794408739?i=1794408745"
                 },
                 "spotify": {
                     "id": "2nrY3Snk7Tqf2QOwzLAWQf"
@@ -13189,7 +13189,7 @@
                     "video_id": "_MQk7UBD17o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/zombie/1859014056?i=1859014586"
+                    "url": "https://geo.music.apple.com/us/album/zombie/1859014056?i=1859014586"
                 },
                 "spotify": {
                     "id": "42GKyvz5KBsHTBaLpo3cqJ"
@@ -13220,7 +13220,7 @@
                     "video_id": "M9xqpkNN2iI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/no-date/1799444116?i=1799444117"
+                    "url": "https://geo.music.apple.com/us/album/no-date/1799444116?i=1799444117"
                 },
                 "spotify": {
                     "id": "7DX8AHCJlg91W9lH9JT5vv"
@@ -13246,7 +13246,7 @@
                     "video_id": "BUPbykxBVnw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/uncomfy-feat-osamason/1830354433?i=1830354436"
+                    "url": "https://geo.music.apple.com/us/album/uncomfy-feat-osamason/1830354433?i=1830354436"
                 },
                 "spotify": {
                     "id": "3W3Y2kXSOkDidmXerJLLU2"
@@ -13272,7 +13272,7 @@
                     "video_id": "OajhPIFvusk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/carita-linda/1839980812?i=1839980818"
+                    "url": "https://geo.music.apple.com/us/album/carita-linda/1839980812?i=1839980818"
                 },
                 "spotify": {
                     "id": "4Xpt2bVLKFvlL5agz7cBTj"
@@ -13298,7 +13298,7 @@
                     "video_id": "uDnOC4KIBXE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/such-a-shame/1797531650?i=1797531841"
+                    "url": "https://geo.music.apple.com/us/album/such-a-shame/1797531650?i=1797531841"
                 },
                 "spotify": {
                     "id": "2bMTr1ekSRhzQqsv1raIlC"
@@ -13324,7 +13324,7 @@
                     "video_id": "BgMU9Vuj17Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/latina-foreva/1819544141?i=1819544623"
+                    "url": "https://geo.music.apple.com/us/album/latina-foreva/1819544141?i=1819544623"
                 },
                 "spotify": {
                     "id": "2KrQbq3aqGOFGnkTKnN2XA"
@@ -13350,7 +13350,7 @@
                     "video_id": "ulrrlJVBdgA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/automatic/1832337743?i=1832337767"
+                    "url": "https://geo.music.apple.com/us/album/automatic/1832337743?i=1832337767"
                 },
                 "spotify": {
                     "id": "3H3kzlDWxN9KEFuUtv39p2"
@@ -13376,7 +13376,7 @@
                     "video_id": "P8m6TfGos1E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/prezzy/1803186824?i=1803186995"
+                    "url": "https://geo.music.apple.com/us/album/prezzy/1803186824?i=1803186995"
                 },
                 "spotify": {
                     "id": "29uMN6cjcQZeozasX35vxq"
@@ -13402,7 +13402,7 @@
                     "video_id": "vF4wrZW8XXE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/will-you-dare/1846453533?i=1846453535"
+                    "url": "https://geo.music.apple.com/us/album/will-you-dare/1846453533?i=1846453535"
                 },
                 "spotify": {
                     "id": "35nEske60pQJNgUrEgf9xW"
@@ -13428,7 +13428,7 @@
                     "video_id": "PMJbIeRbAtc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ctx/1808046844?i=1808046845"
+                    "url": "https://geo.music.apple.com/us/album/ctx/1808046844?i=1808046845"
                 },
                 "spotify": {
                     "id": "6JWlIiYcEgYGNF8oNaMpZP"
@@ -13454,7 +13454,7 @@
                     "video_id": "G6VUFGqWSmk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oblivious/1806624367?i=1806624377"
+                    "url": "https://geo.music.apple.com/us/album/oblivious/1806624367?i=1806624377"
                 },
                 "spotify": {
                     "id": "65hG7wpGsBD591lcfzEmHC"
@@ -13480,7 +13480,7 @@
                     "video_id": "hZ2nxrPHHe0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/taste/1794864306?i=1794864309"
+                    "url": "https://geo.music.apple.com/us/album/taste/1794864306?i=1794864309"
                 },
                 "spotify": {
                     "id": "4uUih1tl2qNtucRds8RZgu"
@@ -13506,7 +13506,7 @@
                     "video_id": "Q196YTCt8KA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/drugs-callin/1845365973?i=1845366348"
+                    "url": "https://geo.music.apple.com/us/album/drugs-callin/1845365973?i=1845366348"
                 },
                 "spotify": {
                     "id": "1WnvTJMxPIoXT7PV9mdNHk"
@@ -13532,7 +13532,7 @@
                     "video_id": "kArHlGTRcMM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/beat-a-b-tch-up/1853587303?i=1853589456"
+                    "url": "https://geo.music.apple.com/us/album/beat-a-b-tch-up/1853587303?i=1853589456"
                 },
                 "spotify": {
                     "id": "5Ky8wE5v2dNXn5XWlBM28k"
@@ -13580,7 +13580,7 @@
                     "video_id": "hv5JM2ndJcE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/enter-claim-feat-divine-earth-angel-seka-tamar-osborn/1796423307?i=1796423318"
+                    "url": "https://geo.music.apple.com/us/album/enter-claim-feat-divine-earth-angel-seka-tamar-osborn/1796423307?i=1796423318"
                 },
                 "spotify": {
                     "id": "0js5CrHTU81zorsAUfi3un"
@@ -13606,7 +13606,7 @@
                     "video_id": "LHGwMtMt6L4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/church-state/1835483605?i=1835483908"
+                    "url": "https://geo.music.apple.com/us/album/church-state/1835483605?i=1835483908"
                 },
                 "spotify": {
                     "id": "3y3RHjj31HtHZEw9zkEoQI"
@@ -13632,7 +13632,7 @@
                     "video_id": "_Cu9Df_9Zvg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gbp/1783404289?i=1783404294"
+                    "url": "https://geo.music.apple.com/us/album/gbp/1783404289?i=1783404294"
                 },
                 "spotify": {
                     "id": "4pftaoQbbheCXSdleWIeDK"
@@ -13658,7 +13658,7 @@
                     "video_id": "okwLfAtfSdg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/noire/1820509805?i=1820510347"
+                    "url": "https://geo.music.apple.com/us/album/noire/1820509805?i=1820510347"
                 },
                 "spotify": {
                     "id": "6eebVrIT3HMKnyJq8PqDG4"
@@ -13707,7 +13707,7 @@
                     "video_id": "IR4ujMOgxA4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/s%C3%A9-miimii-feat-dj-skycee/1826305238?i=1826305239"
+                    "url": "https://geo.music.apple.com/us/album/s%C3%A9-miimii-feat-dj-skycee/1826305238?i=1826305239"
                 },
                 "spotify": {
                     "id": "0GhVtqzmazON0vBT3ktTWQ"
@@ -13732,7 +13732,7 @@
                     "video_id": "klst6CYjGiM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mega-suicidio-auditivo/1819758226?i=1819758228"
+                    "url": "https://geo.music.apple.com/us/album/mega-suicidio-auditivo/1819758226?i=1819758228"
                 },
                 "spotify": {
                     "id": "1WkDLBRal0YO4YUyF8lL32"
@@ -13758,7 +13758,7 @@
                     "video_id": "uLK2r3sG4lE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/push-2-start/1772394609?i=1772394889"
+                    "url": "https://geo.music.apple.com/us/album/push-2-start/1772394609?i=1772394889"
                 },
                 "spotify": {
                     "id": "1Cbl3Yq8rHo7hhDQmLQagU"
@@ -13784,7 +13784,7 @@
                     "video_id": "A9V9X0_AsVs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/yolo/1795899826?i=1795900013"
+                    "url": "https://geo.music.apple.com/us/album/yolo/1795899826?i=1795900013"
                 },
                 "spotify": {
                     "id": "34ZNVmPISt18mxi0V5uHyk"
@@ -13810,7 +13810,7 @@
                     "video_id": "H2qb7k8SZLI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/husbands/1818548779?i=1818548786"
+                    "url": "https://geo.music.apple.com/us/album/husbands/1818548779?i=1818548786"
                 },
                 "spotify": {
                     "id": "0xATIfA17cJDb9pYAuw70Y"
@@ -13836,7 +13836,7 @@
                     "video_id": "goxW4acwOoA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bury-me/1790456398?i=1790456399"
+                    "url": "https://geo.music.apple.com/us/album/bury-me/1790456398?i=1790456399"
                 },
                 "spotify": {
                     "id": "56fy1fC0cxRpoEDMySEGBv"
@@ -13862,7 +13862,7 @@
                     "video_id": "mNgVsdE5XlE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/7-d%C3%ADas/1811879821?i=1811879833"
+                    "url": "https://geo.music.apple.com/us/album/7-d%C3%ADas/1811879821?i=1811879833"
                 },
                 "spotify": {
                     "id": "5Z75FvRFiultmPFWHx5jQ7"
@@ -13888,7 +13888,7 @@
                     "video_id": "SF7k1tH96d0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/run-riot-run/1807310220?i=1807310227"
+                    "url": "https://geo.music.apple.com/us/album/run-riot-run/1807310220?i=1807310227"
                 },
                 "spotify": {
                     "id": "7Fc7XdmrmTUQBoeU8MXIbN"
@@ -13914,7 +13914,7 @@
                     "video_id": "2FX9oNhpzVk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hello-heaven-hello/1799088715?i=1799088716"
+                    "url": "https://geo.music.apple.com/us/album/hello-heaven-hello/1799088715?i=1799088716"
                 },
                 "spotify": {
                     "id": "4WNaefp3sGsnTBzHEQb97g"
@@ -13940,7 +13940,7 @@
                     "video_id": "CAzmJ99gbGg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lift-you-up/1838052961?i=1838053177"
+                    "url": "https://geo.music.apple.com/us/album/lift-you-up/1838052961?i=1838053177"
                 },
                 "spotify": {
                     "id": "4hSTvY4GQrNDC2TsCwhEFc"
@@ -13966,7 +13966,7 @@
                     "video_id": "MMxkxgrv3Vc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/drums-of-death/1824431448?i=1824432089"
+                    "url": "https://geo.music.apple.com/us/album/drums-of-death/1824431448?i=1824432089"
                 },
                 "spotify": {
                     "id": "13QINbzgh3yta5OGvB77Pl"
@@ -13992,7 +13992,7 @@
                     "video_id": "YFF4Hg9Yl6k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pale-song/1843645122?i=1843645126"
+                    "url": "https://geo.music.apple.com/us/album/pale-song/1843645122?i=1843645126"
                 },
                 "spotify": {
                     "id": "5NbilllIdF8lp4FmdX7OF8"
@@ -14023,7 +14023,7 @@
                     "video_id": "xnP7qKxwzjg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dracula/1836226516?i=1836226730"
+                    "url": "https://geo.music.apple.com/us/album/dracula/1836226516?i=1836226730"
                 },
                 "spotify": {
                     "id": "1NXbNEAcPvY5G1xvfN57aA"
@@ -14049,7 +14049,7 @@
                     "video_id": "8emRHIcweck"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wait/1857999850?i=1857999853"
+                    "url": "https://geo.music.apple.com/us/album/wait/1857999850?i=1857999853"
                 },
                 "spotify": {
                     "id": "3zsOkhislzbxzFOSQuPIr9"
@@ -14075,7 +14075,7 @@
                     "video_id": "v-ovw3_PWCY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/imaginary-playerz/1848839006?i=1848839016"
+                    "url": "https://geo.music.apple.com/us/album/imaginary-playerz/1848839006?i=1848839016"
                 },
                 "spotify": {
                     "id": "37tH9V9YK8P9Q2oGfZjJXy"
@@ -14129,7 +14129,7 @@
                     "video_id": "I-jkvVlmsNY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mother-pray-for-me/1817137575?i=1817137581"
+                    "url": "https://geo.music.apple.com/us/album/mother-pray-for-me/1817137575?i=1817137581"
                 },
                 "spotify": {
                     "id": "5RCUuWLW5FcfSisq2V4BMa"
@@ -14173,7 +14173,7 @@
                     "video_id": "gkqxzs0aCXs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gondola/1772112135?i=1772112138"
+                    "url": "https://geo.music.apple.com/us/album/gondola/1772112135?i=1772112138"
                 },
                 "spotify": {
                     "id": "4zND6NKoMq9ZkjvDAHAgqH"
@@ -14199,7 +14199,7 @@
                     "video_id": "Ov297YWG8a0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ricochet/1799291907?i=1799292324"
+                    "url": "https://geo.music.apple.com/us/album/ricochet/1799291907?i=1799292324"
                 },
                 "spotify": {
                     "id": "6cbLpZ56tlJYHueIgfCLzd"
@@ -14225,7 +14225,7 @@
                     "video_id": "VPTW22K7GIM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/somewhere-in-between/1825903903?i=1825903909"
+                    "url": "https://geo.music.apple.com/us/album/somewhere-in-between/1825903903?i=1825903909"
                 },
                 "spotify": {
                     "id": "3wyntMwz2XfUWy3O7ukBbD"
@@ -14251,7 +14251,7 @@
                     "video_id": "5uCA0kiSsT0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/how-to-impress-god/1773434450?i=1773434461"
+                    "url": "https://geo.music.apple.com/us/album/how-to-impress-god/1773434450?i=1773434461"
                 },
                 "spotify": {
                     "id": "1A9NdpGfoDP1369R1xZ4mZ"
@@ -14277,7 +14277,7 @@
                     "video_id": "YN7B3yNX8O0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/star/1846887461?i=1846887462"
+                    "url": "https://geo.music.apple.com/us/album/star/1846887461?i=1846887462"
                 },
                 "spotify": {
                     "id": "0dqAyHWEXNCH83W7uctKTn"
@@ -14308,7 +14308,7 @@
                     "video_id": "cy605Bp-3Bw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/moody/1860400918?i=1860402708"
+                    "url": "https://geo.music.apple.com/us/album/moody/1860400918?i=1860402708"
                 },
                 "spotify": {
                     "id": "6SA3oIwGyURRVZkbvC5lQD"
@@ -14334,7 +14334,7 @@
                     "video_id": "kXovV2keBP4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/self-evident/1845918475?i=1845918479"
+                    "url": "https://geo.music.apple.com/us/album/self-evident/1845918475?i=1845918479"
                 },
                 "spotify": {
                     "id": "36J9vpPpatRDkMkee0PFCe"
@@ -14360,7 +14360,7 @@
                     "video_id": "V_KchwQrS7Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/miami/1822659244?i=1822659245"
+                    "url": "https://geo.music.apple.com/us/album/miami/1822659244?i=1822659245"
                 },
                 "spotify": {
                     "id": "2egIlhalVEVQhvt9W11u82"
@@ -14386,7 +14386,7 @@
                     "video_id": "w6VZ4qm-e0w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/aaahh-men/1834042903?i=1834042906"
+                    "url": "https://geo.music.apple.com/us/album/aaahh-men/1834042903?i=1834042906"
                 },
                 "spotify": {
                     "id": "2qGvxAKXbajPFRb9ybIMOD"
@@ -14412,7 +14412,7 @@
                     "video_id": "KHOSr53EPCQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/4-kamp%C3%A9-ii/1804188206?i=1804188207"
+                    "url": "https://geo.music.apple.com/us/album/4-kamp%C3%A9-ii/1804188206?i=1804188207"
                 },
                 "spotify": {
                     "id": "2fhVsI54lSCFyW7sw5WPfR"
@@ -14438,7 +14438,7 @@
                     "video_id": "OSOEvO4McCM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/letter-from-an-unknown-girlfriend-feat-fiona-apple/1785066667?i=1785066796"
+                    "url": "https://geo.music.apple.com/us/album/letter-from-an-unknown-girlfriend-feat-fiona-apple/1785066667?i=1785066796"
                 },
                 "spotify": {
                     "id": "74hD8ZuQLIZyCr597HHAqJ"
@@ -14464,7 +14464,7 @@
                     "video_id": "NROwKJIw6Jc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/down-for-you/1837337842?i=1837337987"
+                    "url": "https://geo.music.apple.com/us/album/down-for-you/1837337842?i=1837337987"
                 },
                 "spotify": {
                     "id": "5hKjvZFDOkBcJgeT7bF61A"
@@ -14490,7 +14490,7 @@
                     "video_id": "QlfOA4s1_Vc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lighter/1849462595?i=1849462851"
+                    "url": "https://geo.music.apple.com/us/album/lighter/1849462595?i=1849462851"
                 },
                 "spotify": {
                     "id": "5f9JpyT70rksel4mcQg0a7"
@@ -14516,7 +14516,7 @@
                     "video_id": "7dI5837ktzc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/p-o-v/1816313639?i=1816313642"
+                    "url": "https://geo.music.apple.com/us/album/p-o-v/1816313639?i=1816313642"
                 },
                 "spotify": {
                     "id": "0mwlZQjUxspUTpAzLwexw7"
@@ -14542,7 +14542,7 @@
                     "video_id": "VT7C9dEKpfw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bad-choices/1828816937?i=1828816949"
+                    "url": "https://geo.music.apple.com/us/album/bad-choices/1828816937?i=1828816949"
                 },
                 "spotify": {
                     "id": "499OiYFGkuTO74jb9tKv8Z"
@@ -14568,7 +14568,7 @@
                     "video_id": "rONx6cmA088"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/people-watching/1845916617?i=1845916619"
+                    "url": "https://geo.music.apple.com/us/album/people-watching/1845916617?i=1845916619"
                 },
                 "spotify": {
                     "id": "6gBjUipB0ZxHd1BvwdJTDQ"
@@ -14594,7 +14594,7 @@
                     "video_id": "pm41IrkBrwc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/a-doll-fulla-pins-feat-yolanda-watson-jeff-markey/1793411266?i=1793412304"
+                    "url": "https://geo.music.apple.com/us/album/a-doll-fulla-pins-feat-yolanda-watson-jeff-markey/1793411266?i=1793412304"
                 },
                 "spotify": {
                     "id": "5yCnuMeWqqpw6cvXeMD8MH"
@@ -14641,7 +14641,7 @@
                     "video_id": "u2jlWouXz-8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lucif%C3%A9rine/1777069509?i=1777070006"
+                    "url": "https://geo.music.apple.com/us/album/lucif%C3%A9rine/1777069509?i=1777070006"
                 },
                 "spotify": {
                     "id": "4mdgvCTOLBexTX8UrmYyw8"
@@ -14667,7 +14667,7 @@
                     "video_id": "BzmhBijrxl0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/afterlife/1836448841?i=1836448843"
+                    "url": "https://geo.music.apple.com/us/album/afterlife/1836448841?i=1836448843"
                 },
                 "spotify": {
                     "id": "0GQkx88Fpkm7qlbrdggdNO"
@@ -14693,7 +14693,7 @@
                     "video_id": "3KvmrzLS_lA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/white-horses/1812904249?i=1812904939"
+                    "url": "https://geo.music.apple.com/us/album/white-horses/1812904249?i=1812904939"
                 },
                 "spotify": {
                     "id": "5FxdLsAmaOo8ofpNvsSun5"
@@ -14719,7 +14719,7 @@
                     "video_id": "SdUkJbXxVz4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/just-in-case/1802103958?i=1802103977"
+                    "url": "https://geo.music.apple.com/us/album/just-in-case/1802103958?i=1802103977"
                 },
                 "spotify": {
                     "id": "5z0LSDpPpGwc2ZyJHpsE3J"
@@ -14745,7 +14745,7 @@
                     "video_id": "E_gPfRLVn9I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/body-behavior/1792077173?i=1792077183"
+                    "url": "https://geo.music.apple.com/us/album/body-behavior/1792077173?i=1792077183"
                 },
                 "spotify": {
                     "id": "2gFHcEzp9aooYWJgWdkglG"
@@ -14770,7 +14770,7 @@
                     "video_id": "OI5WC4eRURc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/vega/1786366973?i=1786366974"
+                    "url": "https://geo.music.apple.com/us/album/vega/1786366973?i=1786366974"
                 },
                 "spotify": {
                     "id": "0HjYuuMp6oljg3n9me62zP"
@@ -14796,7 +14796,7 @@
                     "video_id": "hezmKltUGbE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mavkast-feat-mavi/1812133466?i=1812133473"
+                    "url": "https://geo.music.apple.com/us/album/mavkast-feat-mavi/1812133466?i=1812133473"
                 },
                 "spotify": {
                     "id": "26S2Z8upUulL1YCMSD4ug2"
@@ -14822,7 +14822,7 @@
                     "video_id": "bYmU3LRwYrI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bite-the-bait/1824330589?i=1824330938"
+                    "url": "https://geo.music.apple.com/us/album/bite-the-bait/1824330589?i=1824330938"
                 },
                 "spotify": {
                     "id": "6pcXJ39XevPFNqXuUDClsf"
@@ -14870,7 +14870,7 @@
                     "video_id": "_szp3ehxssg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/good-intentions/1834954053?i=1834954316"
+                    "url": "https://geo.music.apple.com/us/album/good-intentions/1834954053?i=1834954316"
                 },
                 "spotify": {
                     "id": "0P5PPuVLKdyHnWdjbOeMxa"
@@ -14896,7 +14896,7 @@
                     "video_id": "o3z3pgNvYN8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/echoes/1828653368?i=1828653369"
+                    "url": "https://geo.music.apple.com/us/album/echoes/1828653368?i=1828653369"
                 },
                 "spotify": {
                     "id": "1mVOpAtz7FjGNHvAYYqkVi"
@@ -14924,7 +14924,7 @@
                     "video_id": "4X5a6w2tNY0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/soft-launch/1840078622?i=1840078623"
+                    "url": "https://geo.music.apple.com/us/album/soft-launch/1840078622?i=1840078623"
                 },
                 "spotify": {
                     "id": "05XVJA1uDIULsh4TzWBPap"
@@ -14950,7 +14950,7 @@
                     "video_id": "JKe5rMTVJC8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gimme-dat/1816030211?i=1816030220"
+                    "url": "https://geo.music.apple.com/us/album/gimme-dat/1816030211?i=1816030220"
                 },
                 "spotify": {
                     "id": "1k51Q6GFWBbsaWlBB2gnzo"
@@ -14976,7 +14976,7 @@
                     "video_id": "4-RzlYHlZ5k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dad-i/1821827850?i=1821828064"
+                    "url": "https://geo.music.apple.com/us/album/dad-i/1821827850?i=1821828064"
                 },
                 "spotify": {
                     "id": "6Ar4d3N45kgvYuRYj7yKX6"
@@ -15002,7 +15002,7 @@
                     "video_id": "3Y9w3vtirXY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/talk-you-through-it-feat-flo/1820237151?i=1820237159"
+                    "url": "https://geo.music.apple.com/us/album/talk-you-through-it-feat-flo/1820237151?i=1820237159"
                 },
                 "spotify": {
                     "id": "0XnxrosRIxY1nKFJ7wc5Ut"
@@ -15028,7 +15028,7 @@
                     "video_id": "b25_KxD_P5Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/two-faced/1861928307?i=1861928601"
+                    "url": "https://geo.music.apple.com/us/album/two-faced/1861928307?i=1861928601"
                 },
                 "spotify": {
                     "id": "0z0fnR1VkGhdihpoXOUx6T"
@@ -15054,7 +15054,7 @@
                     "video_id": "qMnVbg61588"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-package/1850512301?i=1850512853"
+                    "url": "https://geo.music.apple.com/us/album/the-package/1850512301?i=1850512853"
                 },
                 "spotify": {
                     "id": "02WYUqxhFKrmsfXeguqlvW"
@@ -15080,7 +15080,7 @@
                     "video_id": "1TrjZ3ZTB0g"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/forever-salty/1791848964?i=1791848969"
+                    "url": "https://geo.music.apple.com/us/album/forever-salty/1791848964?i=1791848969"
                 },
                 "spotify": {
                     "id": "2BNWCIN4nxYbNhcSIol2BG"
@@ -15108,7 +15108,7 @@
                     "video_id": "WGhdJnXxYQU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/im-not-here/1840254522?i=1840254524"
+                    "url": "https://geo.music.apple.com/us/album/im-not-here/1840254522?i=1840254524"
                 },
                 "spotify": {
                     "id": "3BvmHUWrVYDTp7khu6Y5Qm"
@@ -15134,7 +15134,7 @@
                     "video_id": "0Z6XglWa5fE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/begin-again-from-the-vault/1833056997?i=1833057004"
+                    "url": "https://geo.music.apple.com/us/album/begin-again-from-the-vault/1833056997?i=1833057004"
                 },
                 "spotify": {
                     "id": "6vTpNnr2dryDKW5wNpAJJH"
@@ -15160,7 +15160,7 @@
                     "video_id": "fgUXt1bq6Fk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/magic-what-we-do-surreal-montage-feat-miles-caton/1806651595?i=1806651609"
+                    "url": "https://geo.music.apple.com/us/album/magic-what-we-do-surreal-montage-feat-miles-caton/1806651595?i=1806651609"
                 },
                 "spotify": {
                     "id": "3ftYF085hfCdYGB0nus3fW"
@@ -15186,7 +15186,7 @@
                     "video_id": "-mrl3z6V6r0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/revolving-door/1779319620?i=1779319626"
+                    "url": "https://geo.music.apple.com/us/album/revolving-door/1779319620?i=1779319626"
                 },
                 "spotify": {
                     "id": "541sN2qNfIlllGn9nGOQoC"
@@ -15212,7 +15212,7 @@
                     "video_id": "nnzndZQX3SU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nice/1859703551?i=1859703727"
+                    "url": "https://geo.music.apple.com/us/album/nice/1859703551?i=1859703727"
                 },
                 "spotify": {
                     "id": "5QD9PUqyVz8syPaZL4HAbB"
@@ -15261,7 +15261,7 @@
                     "video_id": "hYHQA4qogDM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gumshoe-dracula-from-arkansas/1777296174?i=1777296187"
+                    "url": "https://geo.music.apple.com/us/album/gumshoe-dracula-from-arkansas/1777296174?i=1777296187"
                 },
                 "spotify": {
                     "id": "4I939vqD5prXBpMlyDjbuw"
@@ -15287,7 +15287,7 @@
                     "video_id": "lTALe90M_rI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/real-life/1832581930?i=1832581932"
+                    "url": "https://geo.music.apple.com/us/album/real-life/1832581930?i=1832581932"
                 },
                 "spotify": {
                     "id": "1Dcfp94Bmjnih9IYD6qV6K"
@@ -15313,7 +15313,7 @@
                     "video_id": "IhU0-X2BKxs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/talk-olympics-feat-little-simz/1818405707?i=1818405845"
+                    "url": "https://geo.music.apple.com/us/album/talk-olympics-feat-little-simz/1818405707?i=1818405845"
                 },
                 "spotify": {
                     "id": "04ncMwTyse8X37iIUT4na1"
@@ -15338,7 +15338,7 @@
                     "video_id": "euKXEGv9v7A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/eternitys-pillars/1839331470?i=1839331471"
+                    "url": "https://geo.music.apple.com/us/album/eternitys-pillars/1839331470?i=1839331471"
                 },
                 "spotify": {
                     "id": "3sLQeqH2lSweq47Lr9IPA9"
@@ -15387,7 +15387,7 @@
                     "video_id": "4rL3ATRkeKw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/struggle-with-the-beast/1832516780?i=1832516781"
+                    "url": "https://geo.music.apple.com/us/album/struggle-with-the-beast/1832516780?i=1832516781"
                 },
                 "spotify": {
                     "id": "2Z19DwRllkxjcaMZfAQrNI"
@@ -15416,7 +15416,7 @@
                     "video_id": "s8FczLzzdCw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/spinnin-on-it/1839523838?i=1839523845"
+                    "url": "https://geo.music.apple.com/us/album/spinnin-on-it/1839523838?i=1839523845"
                 },
                 "spotify": {
                     "id": "4pH8rClaLsi6QcDGrw2VgV"
@@ -15442,7 +15442,7 @@
                     "video_id": "xFAKfsjxtFU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dang/1835666611?i=1835668052"
+                    "url": "https://geo.music.apple.com/us/album/dang/1835666611?i=1835668052"
                 },
                 "spotify": {
                     "id": "5l8ylBEHHYL62w5HfjB3JF"
@@ -15468,7 +15468,7 @@
                     "video_id": "oFNfHp56CKg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cuntology-101/1771841531?i=1771842454"
+                    "url": "https://geo.music.apple.com/us/album/cuntology-101/1771841531?i=1771842454"
                 },
                 "spotify": {
                     "id": "3wCJGNuWIoeKHsrZdAybiO"
@@ -15494,7 +15494,7 @@
                     "video_id": "kOd6HLO5di8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/clean/1846833534?i=1846833737"
+                    "url": "https://geo.music.apple.com/us/album/clean/1846833534?i=1846833737"
                 },
                 "spotify": {
                     "id": "0tBXqaYjAqaQp55uRdhgAt"
@@ -15520,7 +15520,7 @@
                     "video_id": "ee9yP9aJbXM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/man-made-of-meat/1802025873?i=1802025876"
+                    "url": "https://geo.music.apple.com/us/album/man-made-of-meat/1802025873?i=1802025876"
                 },
                 "spotify": {
                     "id": "5gR6gTGOGsg9zcR7JhvwQz"
@@ -15546,7 +15546,7 @@
                     "video_id": "huWOakHL7FQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pop/1794251351?i=1794251355"
+                    "url": "https://geo.music.apple.com/us/album/pop/1794251351?i=1794251355"
                 },
                 "spotify": {
                     "id": "0bDEU7hnvPcf3OflOCPUzx"
@@ -15571,7 +15571,7 @@
                     "video_id": "eJbUo_uLtdg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/for-whom-the-fools-toll/1827713420?i=1827713424"
+                    "url": "https://geo.music.apple.com/us/album/for-whom-the-fools-toll/1827713420?i=1827713424"
                 },
                 "spotify": {
                     "id": "2Zrve0SeR4E9ao9EO2z8au"
@@ -15597,7 +15597,7 @@
                     "video_id": "ujIO95oOPPA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/coma/1786650157?i=1786650162"
+                    "url": "https://geo.music.apple.com/us/album/coma/1786650157?i=1786650162"
                 },
                 "spotify": {
                     "id": "5Zkp38EROuQ9Elsep22Ov4"
@@ -15623,7 +15623,7 @@
                     "video_id": "AvK6ZwKinz0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/chemical-reaction/1812965574?i=1812965575"
+                    "url": "https://geo.music.apple.com/us/album/chemical-reaction/1812965574?i=1812965575"
                 },
                 "spotify": {
                     "id": "7AAcT7MunkAjHyk9Abg774"
@@ -15649,7 +15649,7 @@
                     "video_id": "gt8RmZGH5TI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/horribly/1804692805?i=1804692806"
+                    "url": "https://geo.music.apple.com/us/album/horribly/1804692805?i=1804692806"
                 },
                 "spotify": {
                     "id": "59029WsRfhwA8Vqez1QSeY"
@@ -15674,7 +15674,7 @@
                     "video_id": "MtCsMBXuZ84"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/orlando-in-love/1785246760?i=1785246763"
+                    "url": "https://geo.music.apple.com/us/album/orlando-in-love/1785246760?i=1785246763"
                 },
                 "spotify": {
                     "id": "7yDcE8l5OFDRSrsHhqgP4c"
@@ -15700,7 +15700,7 @@
                     "video_id": "DQaMnaqrXaQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/freaky-just-my-type/1801743700?i=1801743707"
+                    "url": "https://geo.music.apple.com/us/album/freaky-just-my-type/1801743700?i=1801743707"
                 },
                 "spotify": {
                     "id": "37Pvim4Q5XnvMFxaUgBwUl"
@@ -15726,7 +15726,7 @@
                     "video_id": "f53z2lid7kM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/savanna/1842990870?i=1842990871"
+                    "url": "https://geo.music.apple.com/us/album/savanna/1842990870?i=1842990871"
                 },
                 "spotify": {
                     "id": "37lYjMF2wbLow8pOJBtIMx"
@@ -15752,7 +15752,7 @@
                     "video_id": "oyqeHp0f5gA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/enough/1825239073?i=1825239137"
+                    "url": "https://geo.music.apple.com/us/album/enough/1825239073?i=1825239137"
                 },
                 "spotify": {
                     "id": "3qkwosSpGEJZYlGApYl4uj"
@@ -15777,7 +15777,7 @@
                     "video_id": "x5wkuLaf998"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/zugzwang/1797102434?i=1797102679"
+                    "url": "https://geo.music.apple.com/us/album/zugzwang/1797102434?i=1797102679"
                 },
                 "spotify": {
                     "id": "71MvaHIcqkUfwiKebC0wBw"
@@ -15803,7 +15803,7 @@
                     "video_id": "UHS10dP62Bs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/everybody-knows-im-sad/1807308262?i=1807308473"
+                    "url": "https://geo.music.apple.com/us/album/everybody-knows-im-sad/1807308262?i=1807308473"
                 },
                 "spotify": {
                     "id": "7EzM6R4sRxT2tcHod3Yf5N"
@@ -15829,7 +15829,7 @@
                     "video_id": "ayBIGxfHCdo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/reframing/1792215329?i=1792215334"
+                    "url": "https://geo.music.apple.com/us/album/reframing/1792215329?i=1792215334"
                 },
                 "spotify": {
                     "id": "0gRPbCjHQ3B5R7LnYdxdJg"
@@ -15855,7 +15855,7 @@
                     "video_id": "QdbwR5iRqlY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/touching-god-feat-yebba-blood-orange/1861540133?i=1861541076"
+                    "url": "https://geo.music.apple.com/us/album/touching-god-feat-yebba-blood-orange/1861540133?i=1861541076"
                 },
                 "spotify": {
                     "id": "3Ws7pcKeEo6dW2xPUFgmQv"
@@ -15881,7 +15881,7 @@
                     "video_id": "a_eZl8n5cyM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/high-on-the-hog/1802758138?i=1802758139"
+                    "url": "https://geo.music.apple.com/us/album/high-on-the-hog/1802758138?i=1802758139"
                 },
                 "spotify": {
                     "id": "6sMsaVXPKzhf01WvaRFAEI"
@@ -15907,7 +15907,7 @@
                     "video_id": "XhKg1z0UmLI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/work-it-out-feat-disco-sam/1827262885?i=1827263194"
+                    "url": "https://geo.music.apple.com/us/album/work-it-out-feat-disco-sam/1827262885?i=1827263194"
                 },
                 "spotify": {
                     "id": "6BLCtuWe2Lpu9vbS52DP19"
@@ -15936,7 +15936,7 @@
                     "video_id": "nhCC1yW4nlU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/fairy/1834276456?i=1834276457"
+                    "url": "https://geo.music.apple.com/us/album/fairy/1834276456?i=1834276457"
                 },
                 "spotify": {
                     "id": "735Ji1GzLR9nvteGdbqy8U"
@@ -15962,7 +15962,7 @@
                     "video_id": "FUHaycnjzKg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/verano-rosa/1819544141?i=1819545310"
+                    "url": "https://geo.music.apple.com/us/album/verano-rosa/1819544141?i=1819545310"
                 },
                 "spotify": {
                     "id": "0nafF9MxcXJBQWv3BTKtdF"
@@ -15988,7 +15988,7 @@
                     "video_id": "vj7ojnHixOg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-happy-dictator-feat-sparks/1837237742?i=1837237767"
+                    "url": "https://geo.music.apple.com/us/album/the-happy-dictator-feat-sparks/1837237742?i=1837237767"
                 },
                 "spotify": {
                     "id": "50BLjPGDh9DjVp4qwwyG6d"
@@ -16014,7 +16014,7 @@
                     "video_id": "4zK8Ry9QGho"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/going-blonde/1813482891?i=1813482892"
+                    "url": "https://geo.music.apple.com/us/album/going-blonde/1813482891?i=1813482892"
                 },
                 "spotify": {
                     "id": "2L795xcNWrKrqdhzmEUVCq"
@@ -16045,7 +16045,7 @@
                     "video_id": "ZO5dovHJS_0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/holy-water/1805237139?i=1805237421"
+                    "url": "https://geo.music.apple.com/us/album/holy-water/1805237139?i=1805237421"
                 },
                 "spotify": {
                     "id": "5nOQxqzBM7DjLpkRMEJNIB"
@@ -16071,7 +16071,7 @@
                     "video_id": "XuwZiYP7XeQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/fluid-mechanics/1792215329?i=1792215348"
+                    "url": "https://geo.music.apple.com/us/album/fluid-mechanics/1792215329?i=1792215348"
                 },
                 "spotify": {
                     "id": "4uyYd09ILlXDhxVo3V5YdP"
@@ -16099,7 +16099,7 @@
                     "video_id": "r1QapH1SIAI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/like-you-better/1821787094?i=1821787095"
+                    "url": "https://geo.music.apple.com/us/album/like-you-better/1821787094?i=1821787095"
                 },
                 "spotify": {
                     "id": "7t4Z19BqZ23ExgdiOP0nf6"
@@ -16125,7 +16125,7 @@
                     "video_id": "zPED9QNZOoI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/die-happy/1846745852?i=1846745853"
+                    "url": "https://geo.music.apple.com/us/album/die-happy/1846745852?i=1846745853"
                 },
                 "spotify": {
                     "id": "4lU0whPQnQn0EMgmF46iz0"
@@ -16151,7 +16151,7 @@
                     "video_id": "PVltfDeGzWs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/21st-century-cool-girl/1809108642?i=1809108645"
+                    "url": "https://geo.music.apple.com/us/album/21st-century-cool-girl/1809108642?i=1809108645"
                 },
                 "spotify": {
                     "id": "3292GQO43rGyNlKmZvY0Es"
@@ -16177,7 +16177,7 @@
                     "video_id": "qg7Ow050amU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/to-the-sandals/1843645122?i=1843645179"
+                    "url": "https://geo.music.apple.com/us/album/to-the-sandals/1843645122?i=1843645179"
                 },
                 "spotify": {
                     "id": "0o1TOuRqbAP2RspbKZmq7P"
@@ -16203,7 +16203,7 @@
                     "video_id": "0A0IZFa1cnk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/look-to-windward/1800532611?i=1800532870"
+                    "url": "https://geo.music.apple.com/us/album/look-to-windward/1800532611?i=1800532870"
                 },
                 "spotify": {
                     "id": "4Lojbtk7XNMdSKRHSFbdkm"
@@ -16229,7 +16229,7 @@
                     "video_id": "Rt4TiER2sNU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dear-icarus/1778847597?i=1778847598"
+                    "url": "https://geo.music.apple.com/us/album/dear-icarus/1778847597?i=1778847598"
                 },
                 "spotify": {
                     "id": "3kAbFnoFDqPIEkt5Nj5dmS"
@@ -16255,7 +16255,7 @@
                     "video_id": "EDaODQhKeSU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/spring/1823644120?i=1823644127"
+                    "url": "https://geo.music.apple.com/us/album/spring/1823644120?i=1823644127"
                 },
                 "spotify": {
                     "id": "05RT6GsIKwEewOcYFGhm9x"
@@ -16281,7 +16281,7 @@
                     "video_id": "vyizn2D9RSk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/downup/1825659802?i=1825660391"
+                    "url": "https://geo.music.apple.com/us/album/downup/1825659802?i=1825660391"
                 },
                 "spotify": {
                     "id": "3NxwCv3ZF7kYcqtLoplsgf"
@@ -16307,7 +16307,7 @@
                     "video_id": "3hNPmLetp0U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sunshine2/1812878260?i=1812878984"
+                    "url": "https://geo.music.apple.com/us/album/sunshine2/1812878260?i=1812878984"
                 },
                 "spotify": {
                     "id": "3Voqx8yWpN1VcK38Ueptjf"
@@ -16333,7 +16333,7 @@
                     "video_id": "x8TN0OPBK-s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nineteen-sixty-five/1830311724?i=1830311726"
+                    "url": "https://geo.music.apple.com/us/album/nineteen-sixty-five/1830311724?i=1830311726"
                 },
                 "spotify": {
                     "id": "4hHsUOXOCyxXyZn2pDEzXX"
@@ -16359,7 +16359,7 @@
                     "video_id": "-9ady71g6eM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pay-the-rent/1787417294?i=1787417296"
+                    "url": "https://geo.music.apple.com/us/album/pay-the-rent/1787417294?i=1787417296"
                 },
                 "spotify": {
                     "id": "3kAgqfc8ENlt0wC5q7EEG7"
@@ -16385,7 +16385,7 @@
                     "video_id": "4d9e7T90UXw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/moon-body-eyes/1820182335?i=1820182703"
+                    "url": "https://geo.music.apple.com/us/album/moon-body-eyes/1820182335?i=1820182703"
                 },
                 "spotify": {
                     "id": "30zm82YogyGUn4S9dE8vcq"
@@ -16411,7 +16411,7 @@
                     "video_id": "dl0vFuy7fNg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-sofa/1812904249?i=1812905184"
+                    "url": "https://geo.music.apple.com/us/album/the-sofa/1812904249?i=1812905184"
                 },
                 "spotify": {
                     "id": "1gqxVK8URuPT86iFbv2vVL"
@@ -16437,7 +16437,7 @@
                     "video_id": "-iBYbLTjJdM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mum-does-the-washing/1831339355?i=1831339359"
+                    "url": "https://geo.music.apple.com/us/album/mum-does-the-washing/1831339355?i=1831339359"
                 },
                 "spotify": {
                     "id": "0b6u5RhZd8H8rVHROCKgsF"
@@ -16463,7 +16463,7 @@
                     "video_id": "mt_-O7gOmV0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dirty-ought-trill/1818393806?i=1818394284"
+                    "url": "https://geo.music.apple.com/us/album/dirty-ought-trill/1818393806?i=1818394284"
                 },
                 "spotify": {
                     "id": "0OhW6F1LavQzbjZSc8YrZG"
@@ -16512,7 +16512,7 @@
                     "video_id": "SS754XSFgDM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/napoleon/1839918603?i=1839918604"
+                    "url": "https://geo.music.apple.com/us/album/napoleon/1839918603?i=1839918604"
                 },
                 "spotify": {
                     "id": "2HkwY8ossKTSESTUTMY4gD"
@@ -16538,7 +16538,7 @@
                     "video_id": "FXyGJ6kEIe4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/headstones/1815507166?i=1815507169"
+                    "url": "https://geo.music.apple.com/us/album/headstones/1815507166?i=1815507169"
                 },
                 "spotify": {
                     "id": "7wtp2m3k1tc6Phm2EsGbDf"
@@ -16564,7 +16564,7 @@
                     "video_id": "KzwZlmsSFog"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/salesman/1803343332?i=1803343334"
+                    "url": "https://geo.music.apple.com/us/album/salesman/1803343332?i=1803343334"
                 },
                 "spotify": {
                     "id": "73nIZ3ufCricmbo1oPZfjt"
@@ -16590,7 +16590,7 @@
                     "video_id": "a32C6eFLxiY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/im-so-serious/1764415405?i=1764415605"
+                    "url": "https://geo.music.apple.com/us/album/im-so-serious/1764415405?i=1764415605"
                 },
                 "spotify": {
                     "id": "15EOCEksKtUd844TrW9Tjv"
@@ -16616,7 +16616,7 @@
                     "video_id": "P_0-vGeir5c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/misery-loves-company/1818449490?i=1818449501"
+                    "url": "https://geo.music.apple.com/us/album/misery-loves-company/1818449490?i=1818449501"
                 },
                 "spotify": {
                     "id": "08GgZyqoP4icrkBMJFu9PN"
@@ -16642,7 +16642,7 @@
                     "video_id": "2Xf2MgASHdw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/600-school/1822358576?i=1822358968"
+                    "url": "https://geo.music.apple.com/us/album/600-school/1822358576?i=1822358968"
                 },
                 "spotify": {
                     "id": "0J5ZUWqmG8QPo46Cbwr53a"
@@ -16691,7 +16691,7 @@
                     "video_id": "JdiFszJ7WyM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/purple-born/1784869383?i=1784869790"
+                    "url": "https://geo.music.apple.com/us/album/purple-born/1784869383?i=1784869790"
                 },
                 "spotify": {
                     "id": "5pieyrAHXvmzv3QeXb96I2"
@@ -16716,7 +16716,7 @@
                     "video_id": "73DYB0n8dvE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gas-station-sushi/1824019687?i=1824019989"
+                    "url": "https://geo.music.apple.com/us/album/gas-station-sushi/1824019687?i=1824019989"
                 },
                 "spotify": {
                     "id": "5OZfeZTa0R88oA4HCZApom"
@@ -16742,7 +16742,7 @@
                     "video_id": "mFHpIolH9G4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/alive/1812873515?i=1812873525"
+                    "url": "https://geo.music.apple.com/us/album/alive/1812873515?i=1812873525"
                 },
                 "spotify": {
                     "id": "3hJg9CMDIGZZnz36BJ9Rh9"
@@ -16787,7 +16787,7 @@
                     "video_id": "vQMHQaZkbHI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lowlight-slowlight/1842340893?i=1842341025"
+                    "url": "https://geo.music.apple.com/us/album/lowlight-slowlight/1842340893?i=1842341025"
                 },
                 "spotify": {
                     "id": "1mgId6GPSfCUUVQW41y5JF"
@@ -16813,7 +16813,7 @@
                     "video_id": "c2Ja2FWmKUk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/crows-ash-tree/1786528742?i=1786528749"
+                    "url": "https://geo.music.apple.com/us/album/crows-ash-tree/1786528742?i=1786528749"
                 },
                 "spotify": {
                     "id": "3Dum7WctMuZgE9xnx7Jgqs"
@@ -16839,7 +16839,7 @@
                     "video_id": "_lSSqZT_Ywg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/arrow/1786241717?i=1786242033"
+                    "url": "https://geo.music.apple.com/us/album/arrow/1786241717?i=1786242033"
                 },
                 "spotify": {
                     "id": "4UKLF1foe7NVs70zSfkkYg"
@@ -16865,7 +16865,7 @@
                     "video_id": "HI9fBUHG5NI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/brain/1812679754?i=1812679922"
+                    "url": "https://geo.music.apple.com/us/album/brain/1812679754?i=1812679922"
                 },
                 "spotify": {
                     "id": "2of9MjqsETuyppM9YphGTl"
@@ -16891,7 +16891,7 @@
                     "video_id": "2_Fot_BWJDI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/2-lungs-feat-styllunknown/1806705832?i=1806705836"
+                    "url": "https://geo.music.apple.com/us/album/2-lungs-feat-styllunknown/1806705832?i=1806705836"
                 },
                 "spotify": {
                     "id": "6Qw3pU5q0ItsgoZMrsht8X"
@@ -16917,7 +16917,7 @@
                     "video_id": "MS8dGXoZxEc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/same-kind-of-lonely/1769087300?i=1769087551"
+                    "url": "https://geo.music.apple.com/us/album/same-kind-of-lonely/1769087300?i=1769087551"
                 },
                 "spotify": {
                     "id": "6U3Kmg0GVjza9ZA3yP1R1C"
@@ -16943,7 +16943,7 @@
                     "video_id": "iW7ADeAFndE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shop-music/1817130240?i=1817130520"
+                    "url": "https://geo.music.apple.com/us/album/shop-music/1817130240?i=1817130520"
                 },
                 "spotify": {
                     "id": "64J1EYisViSUN0LydKHenz"
@@ -16969,7 +16969,7 @@
                     "video_id": "yY6rYOhUu58"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mona-lisa/1836377277?i=1836377760"
+                    "url": "https://geo.music.apple.com/us/album/mona-lisa/1836377277?i=1836377760"
                 },
                 "spotify": {
                     "id": "3eYB75f0hJQqzuQ6uOuzaA"
@@ -16995,7 +16995,7 @@
                     "video_id": "65ESzk45sqY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/skins/1784994066?i=1784994073"
+                    "url": "https://geo.music.apple.com/us/album/skins/1784994066?i=1784994073"
                 },
                 "spotify": {
                     "id": "5munQvyxlq8hZNvTIrKoQT"
@@ -17021,7 +17021,7 @@
                     "video_id": "g3kViflTX60"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-darkest-side/1784317294?i=1784317295"
+                    "url": "https://geo.music.apple.com/us/album/the-darkest-side/1784317294?i=1784317295"
                 },
                 "spotify": {
                     "id": "0R0u3JffYWFrIjfiC2qDQ1"
@@ -17050,7 +17050,7 @@
                     "video_id": "FWA0EN4NSuo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/allbarone/1821219931?i=1821220387"
+                    "url": "https://geo.music.apple.com/us/album/allbarone/1821219931?i=1821220387"
                 },
                 "spotify": {
                     "id": "041DJ4hUI6drOqYgLf3QQG"
@@ -17076,7 +17076,7 @@
                     "video_id": "cfA_U3Ko7KY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/boars/1837765102?i=1837765109"
+                    "url": "https://geo.music.apple.com/us/album/boars/1837765102?i=1837765109"
                 },
                 "spotify": {
                     "id": "0PBX8l4P0FPtNLloE8AjDl"
@@ -17102,7 +17102,7 @@
                     "video_id": "E7FT57HvJZA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/issy/1845135491?i=1845135499"
+                    "url": "https://geo.music.apple.com/us/album/issy/1845135491?i=1845135499"
                 },
                 "spotify": {
                     "id": "1Ewrkpq1CIwGZ5n4nHqNSe"
@@ -17128,7 +17128,7 @@
                     "video_id": "jZ90jnrCVoM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mchakamchaka/1791191459?i=1791191464"
+                    "url": "https://geo.music.apple.com/us/album/mchakamchaka/1791191459?i=1791191464"
                 },
                 "spotify": {
                     "id": "2y3Ml5Fd5yH6dST2GSDeCr"
@@ -17154,7 +17154,7 @@
                     "video_id": "bM3T1Xrf6JM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/angel/1810374600?i=1810374601"
+                    "url": "https://geo.music.apple.com/us/album/angel/1810374600?i=1810374601"
                 },
                 "spotify": {
                     "id": "1DxEWpp5fkrk53D5gkkNOs"
@@ -17183,7 +17183,7 @@
                     "video_id": "YeOmHlpe_Fs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sugar-water-feat-quelle-chris-and-anjimile/1788296577?i=1788296591"
+                    "url": "https://geo.music.apple.com/us/album/sugar-water-feat-quelle-chris-and-anjimile/1788296577?i=1788296591"
                 },
                 "spotify": {
                     "id": "01PqV02iL1GK8noTdDRKDX"
@@ -17209,7 +17209,7 @@
                     "video_id": "yhgU6GqC5e8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dream-as-one-from-avatar-fire-and-ash/1850828908?i=1850828910"
+                    "url": "https://geo.music.apple.com/us/album/dream-as-one-from-avatar-fire-and-ash/1850828908?i=1850828910"
                 },
                 "spotify": {
                     "id": "0OY2nTgPGvyOS3MR1hJES3"
@@ -17235,7 +17235,7 @@
                     "video_id": "Tqz1JEsAFD0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/level-headed-even-smile/1815580683?i=1815580687"
+                    "url": "https://geo.music.apple.com/us/album/level-headed-even-smile/1815580683?i=1815580687"
                 },
                 "spotify": {
                     "id": "63XuKXNisjyZrOXkxqgGIi"
@@ -17261,7 +17261,7 @@
                     "video_id": "9yj_KArQo1w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/come-down/1808053920?i=1808053933"
+                    "url": "https://geo.music.apple.com/us/album/come-down/1808053920?i=1808053933"
                 },
                 "spotify": {
                     "id": "0mAGQ3NUF8X4hP55jGAUxu"
@@ -17287,7 +17287,7 @@
                     "video_id": "89RWfiwLwh0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/glitter/1856396987?i=1856397127"
+                    "url": "https://geo.music.apple.com/us/album/glitter/1856396987?i=1856397127"
                 },
                 "spotify": {
                     "id": "0y9S3dw1MBzHqmTpMTTd0M"
@@ -17313,7 +17313,7 @@
                     "video_id": "AcIqoSLeATs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nosebleeds/1794035285?i=1794035287"
+                    "url": "https://geo.music.apple.com/us/album/nosebleeds/1794035285?i=1794035287"
                 },
                 "spotify": {
                     "id": "3QfxeNMKiOMFxHVLlR1L1c"
@@ -17339,7 +17339,7 @@
                     "video_id": "JwTawHEv5VM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/thank-you-for-recording/1779808073?i=1779808076"
+                    "url": "https://geo.music.apple.com/us/album/thank-you-for-recording/1779808073?i=1779808076"
                 },
                 "spotify": {
                     "id": "4zhTF6LpMWHPuXWY8mNrY7"
@@ -17365,7 +17365,7 @@
                     "video_id": "SpbDwr7HZdw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/devotion/1839605744?i=1839605926"
+                    "url": "https://geo.music.apple.com/us/album/devotion/1839605744?i=1839605926"
                 },
                 "spotify": {
                     "id": "4uyBm26e7ElRigCH6vRbpc"
@@ -17391,7 +17391,7 @@
                     "video_id": "9Ye9sY_nOhk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/coraz%C3%B3n/1810769843?i=1810769844"
+                    "url": "https://geo.music.apple.com/us/album/coraz%C3%B3n/1810769843?i=1810769844"
                 },
                 "spotify": {
                     "id": "5A6SU4vLMAJZbkTy7C7xXJ"
@@ -17417,7 +17417,7 @@
                     "video_id": "f4yRc7CDiYI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/savannah/1792515736?i=1792516223"
+                    "url": "https://geo.music.apple.com/us/album/savannah/1792515736?i=1792516223"
                 },
                 "spotify": {
                     "id": "10eTDWUAyApKsMkHBwZ3Mb"
@@ -17443,7 +17443,7 @@
                     "video_id": "nQqsIeMa7eU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/el-cuc0-0/1839980812?i=1839980825"
+                    "url": "https://geo.music.apple.com/us/album/el-cuc0-0/1839980812?i=1839980825"
                 },
                 "spotify": {
                     "id": "3yBx8j3hVNawnmlrBf3EHR"
@@ -17469,7 +17469,7 @@
                     "video_id": "9q71ywEqJjA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tough-luck/1834263082?i=1834263139"
+                    "url": "https://geo.music.apple.com/us/album/tough-luck/1834263082?i=1834263139"
                 },
                 "spotify": {
                     "id": "5PFjKfGf75I3LkKGiReWp5"
@@ -17495,7 +17495,7 @@
                     "video_id": "4H43ils7p6k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/l-o-a-t/1850445090?i=1850445313"
+                    "url": "https://geo.music.apple.com/us/album/l-o-a-t/1850445090?i=1850445313"
                 },
                 "spotify": {
                     "id": "6N2lPLZFtDOck18VqPpgT2"
@@ -17521,7 +17521,7 @@
                     "video_id": "pT-x9kGwFXY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/audrey-hepburn/1854683629?i=1854683990"
+                    "url": "https://geo.music.apple.com/us/album/audrey-hepburn/1854683629?i=1854683990"
                 },
                 "spotify": {
                     "id": "7hoPbfGuOZe6FKBlwB2d21"
@@ -17547,7 +17547,7 @@
                     "video_id": "spdX1tq7mec"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/money-is-everything/1809015416?i=1809015435"
+                    "url": "https://geo.music.apple.com/us/album/money-is-everything/1809015416?i=1809015435"
                 },
                 "spotify": {
                     "id": "0yKuz6SU0TN3ViDaydV9ti"
@@ -17573,7 +17573,7 @@
                     "video_id": "vPY97B24nC4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/past-life/1806187641?i=1806187892"
+                    "url": "https://geo.music.apple.com/us/album/past-life/1806187641?i=1806187892"
                 },
                 "spotify": {
                     "id": "2MIpkAQVJqQIDf9k4YWoHR"
@@ -17599,7 +17599,7 @@
                     "video_id": "PFAMu53VR5I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ruminating/1846342052?i=1846342058"
+                    "url": "https://geo.music.apple.com/us/album/ruminating/1846342052?i=1846342058"
                 },
                 "spotify": {
                     "id": "0kJAopMxyyqtF1GiIIsgzn"
@@ -17625,7 +17625,7 @@
                     "video_id": "ozcTLsAbOdo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-hate-your-ex-girlfriend-feat-doechii/1810811057?i=1810811268"
+                    "url": "https://geo.music.apple.com/us/album/i-hate-your-ex-girlfriend-feat-doechii/1810811057?i=1810811268"
                 },
                 "spotify": {
                     "id": "7bgYrlMU0S1wfNPPD4A91Z"
@@ -17651,7 +17651,7 @@
                     "video_id": "ukTm71Id0uE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/every-girl-youve-ever-loved-feat-naomi-campbell/1839062794?i=1839063077"
+                    "url": "https://geo.music.apple.com/us/album/every-girl-youve-ever-loved-feat-naomi-campbell/1839062794?i=1839063077"
                 },
                 "spotify": {
                     "id": "22WFoPT9VIJlZ0VcJVkCpm"
@@ -17677,7 +17677,7 @@
                     "video_id": "cS1AMoH4oA8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mother-wound/1792515736?i=1792516239"
+                    "url": "https://geo.music.apple.com/us/album/mother-wound/1792515736?i=1792516239"
                 },
                 "spotify": {
                     "id": "2RMtMVvGaQMW4sVfnb4bHy"
@@ -17703,7 +17703,7 @@
                     "video_id": "HAZGQG3yHNo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sad-and-beautiful-world/1830973672?i=1830973680"
+                    "url": "https://geo.music.apple.com/us/album/sad-and-beautiful-world/1830973672?i=1830973680"
                 },
                 "spotify": {
                     "id": "6UFDma78AVAyHaN4i88R8i"
@@ -17729,7 +17729,7 @@
                     "video_id": "nMxbju8KEaU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/fault-line/1849992632?i=1849992633"
+                    "url": "https://geo.music.apple.com/us/album/fault-line/1849992632?i=1849992633"
                 },
                 "spotify": {
                     "id": "16hJb6Q1lb22hVc4IsJoCo"
@@ -17755,7 +17755,7 @@
                     "video_id": "t04Sd4kG8OI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bovine-excision/1784280001?i=1784280388"
+                    "url": "https://geo.music.apple.com/us/album/bovine-excision/1784280001?i=1784280388"
                 },
                 "spotify": {
                     "id": "1ILW9DXQGKm3IQRbetzDrM"
@@ -17781,7 +17781,7 @@
                     "video_id": "6msW1iM7GFI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/favourite-daughter/1810905299?i=1810905311"
+                    "url": "https://geo.music.apple.com/us/album/favourite-daughter/1810905299?i=1810905311"
                 },
                 "spotify": {
                     "id": "6FRKxwDHTDGr1lqQ0SEprH"
@@ -17806,7 +17806,7 @@
                     "video_id": "r0m-6IehyL0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/light-sleeper/1828414457?i=1828414460"
+                    "url": "https://geo.music.apple.com/us/album/light-sleeper/1828414457?i=1828414460"
                 },
                 "spotify": {
                     "id": "6oaajUONqaImKe2Gc9oE2b"
@@ -17832,7 +17832,7 @@
                     "video_id": "-Kc8CjBezvY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/weight-of-the-wheel/1790478191?i=1790478687"
+                    "url": "https://geo.music.apple.com/us/album/weight-of-the-wheel/1790478191?i=1790478687"
                 },
                 "spotify": {
                     "id": "495mmtvar5j0qADxhhdDZT"
@@ -17861,7 +17861,7 @@
                     "video_id": "O0DgxEW0vGQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/morena/1793946413?i=1793946422"
+                    "url": "https://geo.music.apple.com/us/album/morena/1793946413?i=1793946422"
                 },
                 "spotify": {
                     "id": "4oB8Xd7gMlUEtWoD8bmCXW"
@@ -17887,7 +17887,7 @@
                     "video_id": "JCcTUYoL570"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/good-friends-call-me-e/1790880741?i=1790880756"
+                    "url": "https://geo.music.apple.com/us/album/good-friends-call-me-e/1790880741?i=1790880756"
                 },
                 "spotify": {
                     "id": "0NH6yKue0LAEc0MitqOmwx"
@@ -17913,7 +17913,7 @@
                     "video_id": "N4pABSvtgC4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/copycats/1838052961?i=1838053174"
+                    "url": "https://geo.music.apple.com/us/album/copycats/1838052961?i=1838053174"
                 },
                 "spotify": {
                     "id": "2NJDGk8pc3f7f3FisD7YKu"
@@ -17938,7 +17938,7 @@
                     "video_id": "JoNohOkscNY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/taking-inventory-of-a-frozen-lake/1786153381?i=1786153382"
+                    "url": "https://geo.music.apple.com/us/album/taking-inventory-of-a-frozen-lake/1786153381?i=1786153382"
                 },
                 "spotify": {
                     "id": "6qEhqLzsiYzipyTdOR0YKe"
@@ -17964,7 +17964,7 @@
                     "video_id": "xyHLsZnWzOU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oneida/1818393806?i=1818394045"
+                    "url": "https://geo.music.apple.com/us/album/oneida/1818393806?i=1818394045"
                 },
                 "spotify": {
                     "id": "5dUCixiCL0CcIUdlgUl1ct"
@@ -17990,7 +17990,7 @@
                     "video_id": "t3KtKHmGFwU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/scene-2-the-run/1786720029?i=1786720031"
+                    "url": "https://geo.music.apple.com/us/album/scene-2-the-run/1786720029?i=1786720031"
                 },
                 "spotify": {
                     "id": "40rE8O0fEkaMjDpEpUDE72"
@@ -18015,7 +18015,7 @@
                     "video_id": "smDTaXVjra8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mortals/1821404501?i=1821404967"
+                    "url": "https://geo.music.apple.com/us/album/mortals/1821404501?i=1821404967"
                 },
                 "spotify": {
                     "id": "1RnaZq4I3JIkzxRAlTQsv8"
@@ -18041,7 +18041,7 @@
                     "video_id": "LCEqe50p8Bw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bologna-feat-fiver/1839207466?i=1839207837"
+                    "url": "https://geo.music.apple.com/us/album/bologna-feat-fiver/1839207466?i=1839207837"
                 },
                 "spotify": {
                     "id": "0yzIr8JB1jI78nP3KFtXVi"
@@ -18067,7 +18067,7 @@
                     "video_id": "MgDef9EWRbg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/16-25/1824662174?i=1824662181"
+                    "url": "https://geo.music.apple.com/us/album/16-25/1824662174?i=1824662181"
                 },
                 "spotify": {
                     "id": "1uIRlFoNdyc8CBBBXFO9Yk"
@@ -18093,7 +18093,7 @@
                     "video_id": "eXMwRGlYDBU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/rich-sinners/1833061731?i=1833061734"
+                    "url": "https://geo.music.apple.com/us/album/rich-sinners/1833061731?i=1833061734"
                 },
                 "spotify": {
                     "id": "7wV5to0AMAWttuxTeTUzjP"
@@ -18119,7 +18119,7 @@
                     "video_id": "SHYbofuWQjQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dusty/1786587477?i=1786587481"
+                    "url": "https://geo.music.apple.com/us/album/dusty/1786587477?i=1786587481"
                 },
                 "spotify": {
                     "id": "0TR6bZ12pF2qC0XqpuXYkY"
@@ -18144,7 +18144,7 @@
                     "video_id": "pwXqJRoDXS4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/9th-heaven/1793491480?i=1793491485"
+                    "url": "https://geo.music.apple.com/us/album/9th-heaven/1793491480?i=1793491485"
                 },
                 "spotify": {
                     "id": "0r0vefzAdFKRAHTPTfz5f1"
@@ -18170,7 +18170,7 @@
                     "video_id": "czbIhMtK0do"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/draggin/1786587477?i=1786587483"
+                    "url": "https://geo.music.apple.com/us/album/draggin/1786587477?i=1786587483"
                 },
                 "spotify": {
                     "id": "15U5ilubQiS4aiiFO3zuZE"
@@ -18196,7 +18196,7 @@
                     "video_id": "A54wqKoOR8A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/siestas-ah%C3%AD/1841973440?i=1841973694"
+                    "url": "https://geo.music.apple.com/us/album/siestas-ah%C3%AD/1841973440?i=1841973694"
                 },
                 "spotify": {
                     "id": "5RDnvWoNADi1p9FFKSF9UH"
@@ -18222,7 +18222,7 @@
                     "video_id": "wqevZ42Lw2w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/passacaglia-on-a-theme-by-radiohead/1793536706?i=1793536721"
+                    "url": "https://geo.music.apple.com/us/album/passacaglia-on-a-theme-by-radiohead/1793536706?i=1793536721"
                 },
                 "spotify": {
                     "id": "1c7tRNPQtflMTHSGiQ4Kfo"
@@ -18248,7 +18248,7 @@
                     "video_id": "78szqJppaeQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mud/1815356726?i=1815356727"
+                    "url": "https://geo.music.apple.com/us/album/mud/1815356726?i=1815356727"
                 },
                 "spotify": {
                     "id": "0BWJp4pLRHFVKJmDEIlrVn"
@@ -18274,7 +18274,7 @@
                     "video_id": "ocRM4_B2rUU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/jesus-and-john-wayne/1814017952?i=1814017954"
+                    "url": "https://geo.music.apple.com/us/album/jesus-and-john-wayne/1814017952?i=1814017954"
                 },
                 "spotify": {
                     "id": "6okV8XV4EFSxpVnP0zM2vF"
@@ -18300,7 +18300,7 @@
                     "video_id": "KsygeZpLMs4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-greatest-bend-over/1824327172?i=1824327173"
+                    "url": "https://geo.music.apple.com/us/album/the-greatest-bend-over/1824327172?i=1824327173"
                 },
                 "spotify": {
                     "id": "5eCp47PfcZy61mDNdCZz1X"
@@ -18326,7 +18326,7 @@
                     "video_id": "FgXGikFz77g"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/gnawa/1816167839?i=1816167854"
+                    "url": "https://geo.music.apple.com/us/album/gnawa/1816167839?i=1816167854"
                 },
                 "spotify": {
                     "id": "7BXa6HC5lF5HsZsWvOfTll"
@@ -18352,7 +18352,7 @@
                     "video_id": "nHehqsC514A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/freedom-day-part-2-feat-weedie-braimah-milena-casado/1833075629?i=1833075984"
+                    "url": "https://geo.music.apple.com/us/album/freedom-day-part-2-feat-weedie-braimah-milena-casado/1833075629?i=1833075984"
                 },
                 "spotify": {
                     "id": "5KpCKUZAtQ47udFS7iL2GG"
@@ -18378,7 +18378,7 @@
                     "video_id": "QTY2dZeC4B8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/diversey-beach/1796063319?i=1796063328"
+                    "url": "https://geo.music.apple.com/us/album/diversey-beach/1796063319?i=1796063328"
                 },
                 "spotify": {
                     "id": "3L0Rhwoqzo3vkvazlg7iml"
@@ -18404,7 +18404,7 @@
                     "video_id": "ig1kUt__7eo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/passacaglia-al-modo-mio/1826581965?i=1826581976"
+                    "url": "https://geo.music.apple.com/us/album/passacaglia-al-modo-mio/1826581965?i=1826581976"
                 },
                 "spotify": {
                     "id": "7oXSZE2uUBQNrFciE3SYF5"
@@ -18430,7 +18430,7 @@
                     "video_id": "evRVGubWLRM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tardis-hardest/1773425882?i=1773425883"
+                    "url": "https://geo.music.apple.com/us/album/tardis-hardest/1773425882?i=1773425883"
                 },
                 "spotify": {
                     "id": "1ih5mv61q3ls0gjCfq8mc2"
@@ -18456,7 +18456,7 @@
                     "video_id": "TKZO53hIqi8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/para-ti/1836320628?i=1836320959"
+                    "url": "https://geo.music.apple.com/us/album/para-ti/1836320628?i=1836320959"
                 },
                 "spotify": {
                     "id": "29ih3bl2AvGOhfZ4TpZWne"
@@ -18482,7 +18482,7 @@
                     "video_id": "-5nXPMmqtjM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tell-it-back-to-me/1797531650?i=1797531667"
+                    "url": "https://geo.music.apple.com/us/album/tell-it-back-to-me/1797531650?i=1797531667"
                 },
                 "spotify": {
                     "id": "1dcqHqkAeRAQr8SJcL5sIu"
@@ -18508,7 +18508,7 @@
                     "video_id": "4OdVA0gTKjQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cuatro-vidas/1801970393?i=1801970397"
+                    "url": "https://geo.music.apple.com/us/album/cuatro-vidas/1801970393?i=1801970397"
                 },
                 "spotify": {
                     "id": "2yqQFMqf5gDz128rSn5rIF"
@@ -18534,7 +18534,7 @@
                     "video_id": "7yryb6BFXqU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/high-vibrations/1835996465?i=1835996822"
+                    "url": "https://geo.music.apple.com/us/album/high-vibrations/1835996465?i=1835996822"
                 },
                 "spotify": {
                     "id": "0gr9ny9UGmMdrBV1ivgnGb"
@@ -18560,7 +18560,7 @@
                     "video_id": "JxIanxzFkds"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sophia/1790298374?i=1790298375"
+                    "url": "https://geo.music.apple.com/us/album/sophia/1790298374?i=1790298375"
                 },
                 "spotify": {
                     "id": "24fwLB47pPPSnMTs9Q3jHj"
@@ -18586,7 +18586,7 @@
                     "video_id": "GKcxVVsQ-5M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/defense/1844436601?i=1844437073"
+                    "url": "https://geo.music.apple.com/us/album/defense/1844436601?i=1844437073"
                 },
                 "spotify": {
                     "id": "1pIztA2k0YEP1wXBXx84wM"
@@ -18612,7 +18612,7 @@
                     "video_id": "pncm2ot1ZmA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/back-in-town/1799939683?i=1799939854"
+                    "url": "https://geo.music.apple.com/us/album/back-in-town/1799939683?i=1799939854"
                 },
                 "spotify": {
                     "id": "2UYMqEc8YckMucNfU6z7nc"
@@ -18638,7 +18638,7 @@
                     "video_id": "5K-TCwG0RnA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-one/1838013723?i=1838013724"
+                    "url": "https://geo.music.apple.com/us/album/the-one/1838013723?i=1838013724"
                 },
                 "spotify": {
                     "id": "5CVH4yjJy1Nhr1G51UBG7e"
@@ -18664,7 +18664,7 @@
                     "video_id": "_rFmAAuGVJM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/shovel/1769587122?i=1769587126"
+                    "url": "https://geo.music.apple.com/us/album/shovel/1769587122?i=1769587126"
                 },
                 "spotify": {
                     "id": "1W8DLum7yPDyIS3TYjWIGO"
@@ -18690,7 +18690,7 @@
                     "video_id": "sAreNAfA48k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/go-girl/1853929060?i=1853929064"
+                    "url": "https://geo.music.apple.com/us/album/go-girl/1853929060?i=1853929064"
                 },
                 "spotify": {
                     "id": "7eCAw2VS0UhbsiSItwWdvl"
@@ -18716,7 +18716,7 @@
                     "video_id": "ge4M2dVBgTw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/saiyaara-from-saiyaara/1817818677?i=1817818678"
+                    "url": "https://geo.music.apple.com/us/album/saiyaara-from-saiyaara/1817818677?i=1817818678"
                 },
                 "spotify": {
                     "id": "5SSZtFWdrmFV4MxtlRA13N"
@@ -18742,7 +18742,7 @@
                     "video_id": "GFylNzdzENE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/nunc-dimittis/1826061393?i=1826061394"
+                    "url": "https://geo.music.apple.com/us/album/nunc-dimittis/1826061393?i=1826061394"
                 },
                 "spotify": {
                     "id": "27sawTG6Xm91X7Wn06AwWI"
@@ -18768,7 +18768,7 @@
                     "video_id": "tEV5I2DbasU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/miles-away/1818423617?i=1818423620"
+                    "url": "https://geo.music.apple.com/us/album/miles-away/1818423617?i=1818423620"
                 },
                 "spotify": {
                     "id": "2qXccbob5VYKTZ3D1nVIlp"
@@ -18794,7 +18794,7 @@
                     "video_id": "OxQUf7DHFnE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/endless-tree/1790347369?i=1790347381"
+                    "url": "https://geo.music.apple.com/us/album/endless-tree/1790347369?i=1790347381"
                 },
                 "spotify": {
                     "id": "4mYAxNUCvuUqAQj5Qh3Poq"
@@ -18820,7 +18820,7 @@
                     "video_id": "ISnwwcFsmWw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/betty/1818449490?i=1818449496"
+                    "url": "https://geo.music.apple.com/us/album/betty/1818449490?i=1818449496"
                 },
                 "spotify": {
                     "id": "6QN5ClFa3Ul4kFzsdw3Z8t"
@@ -18846,7 +18846,7 @@
                     "video_id": "1N26te5iEKM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/re-forro/1797880735?i=1797880740"
+                    "url": "https://geo.music.apple.com/us/album/re-forro/1797880735?i=1797880740"
                 },
                 "spotify": {
                     "id": "1qB1YwUoz2xrk18SoejACp"
@@ -18872,7 +18872,7 @@
                     "video_id": "X3l2Q2ZoBzA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/subi%C3%B3-el-maldito-dolar/1842728630?i=1842728631"
+                    "url": "https://geo.music.apple.com/us/album/subi%C3%B3-el-maldito-dolar/1842728630?i=1842728631"
                 },
                 "spotify": {
                     "id": "3GRimmgSiA1Dgh2B9P1HTZ"
@@ -18898,7 +18898,7 @@
                     "video_id": "O32U33KYqAU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/where-the-bar-is/1786397643?i=1786397644"
+                    "url": "https://geo.music.apple.com/us/album/where-the-bar-is/1786397643?i=1786397644"
                 },
                 "spotify": {
                     "id": "6KImrdTSnqqD5Pmfj0mjcz"
@@ -18924,7 +18924,7 @@
                     "video_id": "ggN4SRDDOr4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/vivid-light/1825903903?i=1825903913"
+                    "url": "https://geo.music.apple.com/us/album/vivid-light/1825903903?i=1825903913"
                 },
                 "spotify": {
                     "id": "5AvrkGFKSu7Hj66y7BPiBE"
@@ -18950,7 +18950,7 @@
                     "video_id": "weVHYye3NHs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/paradise/1797634063?i=1797634068"
+                    "url": "https://geo.music.apple.com/us/album/paradise/1797634063?i=1797634068"
                 },
                 "spotify": {
                     "id": "0f8aTAJ49LTQStXC6BB2uw"
@@ -18976,7 +18976,7 @@
                     "video_id": "zviSHh6eH_M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ballet-for-the-elephant-in-the-room-feat-mae-sun/1810795918?i=1810796158"
+                    "url": "https://geo.music.apple.com/us/album/ballet-for-the-elephant-in-the-room-feat-mae-sun/1810795918?i=1810796158"
                 },
                 "spotify": {
                     "id": "7K7yIe5w41Fk8ndI1DDwu0"
@@ -19002,7 +19002,7 @@
                     "video_id": "R2FYu05vZL8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mr-president/1846006072?i=1846006083"
+                    "url": "https://geo.music.apple.com/us/album/mr-president/1846006072?i=1846006083"
                 },
                 "spotify": {
                     "id": "5UDJO7XT3AywHB3gGotlfn"
@@ -19028,7 +19028,7 @@
                     "video_id": "41NFUjskVbo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-cant-stop/1784551087?i=1784551249"
+                    "url": "https://geo.music.apple.com/us/album/i-cant-stop/1784551087?i=1784551249"
                 },
                 "spotify": {
                     "id": "6jazPnayM84A0iELuIrvy8"
@@ -19054,7 +19054,7 @@
                     "video_id": "7h-dG4Rhflc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/rose-ave-feat-niontay/1837272751?i=1837272766"
+                    "url": "https://geo.music.apple.com/us/album/rose-ave-feat-niontay/1837272751?i=1837272766"
                 },
                 "spotify": {
                     "id": "3C6s0G3TW6VBEvZMZWhD6f"
@@ -19080,7 +19080,7 @@
                     "video_id": "MftC0rNdz8M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lonesome-drifter/1792234260?i=1792234261"
+                    "url": "https://geo.music.apple.com/us/album/lonesome-drifter/1792234260?i=1792234261"
                 },
                 "spotify": {
                     "id": "1V48XXuIxK1jIpVoTI4aqn"
@@ -19106,7 +19106,7 @@
                     "video_id": "GB5joWhc704"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wazira-%D9%88%D8%B2%D9%8A%D8%B1%D8%A9/1792092768?i=1792093192"
+                    "url": "https://geo.music.apple.com/us/album/wazira-%D9%88%D8%B2%D9%8A%D8%B1%D8%A9/1792092768?i=1792093192"
                 },
                 "spotify": {
                     "id": "22I9OYOLQPVQOZpr3daoaz"
@@ -19132,7 +19132,7 @@
                     "video_id": "rcArrbixHrI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/beers-with-my-name-on-them/1813481039?i=1813481043"
+                    "url": "https://geo.music.apple.com/us/album/beers-with-my-name-on-them/1813481039?i=1813481043"
                 },
                 "spotify": {
                     "id": "46ik88q0awURfYD4NAuuKM"
@@ -19158,7 +19158,7 @@
                     "video_id": "3uM-VekTlL8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/room-on-the-porch-feat-ruby-amanfu/1792305379?i=1792305386"
+                    "url": "https://geo.music.apple.com/us/album/room-on-the-porch-feat-ruby-amanfu/1792305379?i=1792305386"
                 },
                 "spotify": {
                     "id": "0H1wDrRjC8VBO0mQNwQM9l"
@@ -19206,7 +19206,7 @@
                     "video_id": "FhMQA5J7bvo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pardy/1798848700?i=1798848982"
+                    "url": "https://geo.music.apple.com/us/album/pardy/1798848700?i=1798848982"
                 },
                 "spotify": {
                     "id": "3HgSn2nlDVwnvlStwaA19M"
@@ -19232,7 +19232,7 @@
                     "video_id": "jkC9mNnPqbw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/we-didnt-know-we-were-ready-feat-niamh-regan-ye-vagabonds/1842966710?i=1842967003"
+                    "url": "https://geo.music.apple.com/us/album/we-didnt-know-we-were-ready-feat-niamh-regan-ye-vagabonds/1842966710?i=1842967003"
                 },
                 "spotify": {
                     "id": "2P362P669T4HGZQeFVucgO"
@@ -19258,7 +19258,7 @@
                     "video_id": "AVWHJlhH-3s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/just-cant-wait/1805175466?i=1805175834"
+                    "url": "https://geo.music.apple.com/us/album/just-cant-wait/1805175466?i=1805175834"
                 },
                 "spotify": {
                     "id": "1lMzRNvQfaZ964LSneGOzc"
@@ -19284,7 +19284,7 @@
                     "video_id": "CDBMk8oLVyo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/phoenix/1772947556?i=1772947569"
+                    "url": "https://geo.music.apple.com/us/album/phoenix/1772947556?i=1772947569"
                 },
                 "spotify": {
                     "id": "2SyimHymIiWH0crMcyT7Lt"
@@ -19310,7 +19310,7 @@
                     "video_id": "ETsCxaECchk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/falling-from-and-further/1817695127?i=1817695129"
+                    "url": "https://geo.music.apple.com/us/album/falling-from-and-further/1817695127?i=1817695129"
                 },
                 "spotify": {
                     "id": "4AvGbMjGVkqC8Kmxn6EUQP"
@@ -19336,7 +19336,7 @@
                     "video_id": "-T_UkMkmnV0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/new-orleans/1825239073?i=1825239088"
+                    "url": "https://geo.music.apple.com/us/album/new-orleans/1825239073?i=1825239088"
                 },
                 "spotify": {
                     "id": "4tRs24qn4k5XJ4A9neXPEe"
@@ -19362,7 +19362,7 @@
                     "video_id": "QVVSL9SbGKA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wildfire-season/1842752120?i=1842752123"
+                    "url": "https://geo.music.apple.com/us/album/wildfire-season/1842752120?i=1842752123"
                 },
                 "spotify": {
                     "id": "4sKWDLQiPel0R6sAkWF0tk"
@@ -19388,7 +19388,7 @@
                     "video_id": "TXybH7MeSbg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pinnacle/1821548637?i=1821548886"
+                    "url": "https://geo.music.apple.com/us/album/pinnacle/1821548637?i=1821548886"
                 },
                 "spotify": {
                     "id": "6VMFoZXQPfDKLq9bX9i0Q4"
@@ -19414,7 +19414,7 @@
                     "video_id": "y3MtGN3zb1U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/first-place/1839605744?i=1839605921"
+                    "url": "https://geo.music.apple.com/us/album/first-place/1839605744?i=1839605921"
                 },
                 "spotify": {
                     "id": "4ZZJ7S4Z1pEIvTUgN1oRzS"
@@ -19440,7 +19440,7 @@
                     "video_id": "bYXQDQSO6rE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hundred-acres-feat-devin-morrison/1845391797?i=1845391798"
+                    "url": "https://geo.music.apple.com/us/album/hundred-acres-feat-devin-morrison/1845391797?i=1845391798"
                 },
                 "spotify": {
                     "id": "2UDS0XpaqKrMv7wbVtWIlX"
@@ -19466,7 +19466,7 @@
                     "video_id": "AqUbZvi2IXU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/stranger/1792022220?i=1792022227"
+                    "url": "https://geo.music.apple.com/us/album/stranger/1792022220?i=1792022227"
                 },
                 "spotify": {
                     "id": "7EQhvDdN2fyDHm5OQyCKfz"
@@ -19492,7 +19492,7 @@
                     "video_id": "qUUJYPGABxk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lonely-road/1805220304?i=1805220629"
+                    "url": "https://geo.music.apple.com/us/album/lonely-road/1805220304?i=1805220629"
                 },
                 "spotify": {
                     "id": "0DPDLv364qNKdKY8XZORsW"
@@ -19518,7 +19518,7 @@
                     "video_id": "yfp7q1-lGJs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/peter-and-the-wolf/1811626093?i=1811626099"
+                    "url": "https://geo.music.apple.com/us/album/peter-and-the-wolf/1811626093?i=1811626099"
                 },
                 "spotify": {
                     "id": "3ZIUgIKpnUgCubcGx02oYn"
@@ -19544,7 +19544,7 @@
                     "video_id": "aueShfNZ8Dk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/everything/1819773126?i=1819773137"
+                    "url": "https://geo.music.apple.com/us/album/everything/1819773126?i=1819773137"
                 },
                 "spotify": {
                     "id": "725UQBe7B0hNAAlB8G0ni3"
@@ -19570,7 +19570,7 @@
                     "video_id": "yrqzBy8nG10"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hey-girl-s/1786655540?i=1786655542"
+                    "url": "https://geo.music.apple.com/us/album/hey-girl-s/1786655540?i=1786655542"
                 },
                 "spotify": {
                     "id": "470gEf45gAhLewLVc5IkKJ"
@@ -19596,7 +19596,7 @@
                     "video_id": "Hkk5XoPoHXM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/we-on-dat/1822621534?i=1822621536"
+                    "url": "https://geo.music.apple.com/us/album/we-on-dat/1822621534?i=1822621536"
                 },
                 "spotify": {
                     "id": "7lZAVKwXTXcxp2RPF1R2U6"
@@ -19622,7 +19622,7 @@
                     "video_id": "GIdUiprGsrY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/doves/1801692300?i=1801692303"
+                    "url": "https://geo.music.apple.com/us/album/doves/1801692300?i=1801692303"
                 },
                 "spotify": {
                     "id": "1iX31GXHssJ7YETdIPuCCS"
@@ -19648,7 +19648,7 @@
                     "video_id": "nbDdtTtdwL4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/music-will-explain/1799053835?i=1799054104"
+                    "url": "https://geo.music.apple.com/us/album/music-will-explain/1799053835?i=1799054104"
                 },
                 "spotify": {
                     "id": "2CUNyfC2gWwdPr1SffaXtN"
@@ -19674,7 +19674,7 @@
                     "video_id": "vuOxgGtdXUs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bold-feat-sullivan-fortner-joel-ross-dezron-douglas/1826608051?i=1826608054"
+                    "url": "https://geo.music.apple.com/us/album/bold-feat-sullivan-fortner-joel-ross-dezron-douglas/1826608051?i=1826608054"
                 },
                 "spotify": {
                     "id": "53RjACGjiYw1SathAyoFuy"
@@ -19700,7 +19700,7 @@
                     "video_id": "WqG0gZpM0TY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/phone-me/1771508964?i=1771508978"
+                    "url": "https://geo.music.apple.com/us/album/phone-me/1771508964?i=1771508978"
                 },
                 "spotify": {
                     "id": "7lbbOGDYKIqpcWHdJlfvqJ"
@@ -19726,7 +19726,7 @@
                     "video_id": "cE3t167gx2I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/free/1794880972?i=1794880991"
+                    "url": "https://geo.music.apple.com/us/album/free/1794880972?i=1794880991"
                 },
                 "spotify": {
                     "id": "05n0mwlh1y3cwjGmHnfVjh"
@@ -19752,7 +19752,7 @@
                     "video_id": "HfpR4tAmI7E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/love-me-not/1861768413?i=1861768873"
+                    "url": "https://geo.music.apple.com/us/album/love-me-not/1861768413?i=1861768873"
                 },
                 "spotify": {
                     "id": "4WFgvKVfEhb3IUAFGrutTR"
@@ -19778,7 +19778,7 @@
                     "video_id": "gLwev5sWQXM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wreck/1820224734?i=1820224832"
+                    "url": "https://geo.music.apple.com/us/album/wreck/1820224734?i=1820224832"
                 },
                 "spotify": {
                     "id": "2N0e3WdwtkeDSAC8sqvP9a"
@@ -19804,7 +19804,7 @@
                     "video_id": "KfKI3_uuLqk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mourners/1789353628?i=1789353646"
+                    "url": "https://geo.music.apple.com/us/album/mourners/1789353628?i=1789353646"
                 },
                 "spotify": {
                     "id": "7bu6uhjZ07Qm4sMq1Ooecp"
@@ -19830,7 +19830,7 @@
                     "video_id": "qUG0vA6E5KY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/spades/1785093516?i=1785093521"
+                    "url": "https://geo.music.apple.com/us/album/spades/1785093516?i=1785093521"
                 },
                 "spotify": {
                     "id": "3fmUDp9n9ulLqFRDrbzSnK"
@@ -19856,7 +19856,7 @@
                     "video_id": "06LGD0T8Gq4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/da-problem-solva/1803703306?i=1803703308"
+                    "url": "https://geo.music.apple.com/us/album/da-problem-solva/1803703306?i=1803703308"
                 },
                 "spotify": {
                     "id": "6dXdZKMIWP78xQg2aMl89C"
@@ -19882,7 +19882,7 @@
                     "video_id": "XuItU6RF39A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-trial-feat-reek-da-villian-pills/1828492285?i=1828492561"
+                    "url": "https://geo.music.apple.com/us/album/the-trial-feat-reek-da-villian-pills/1828492285?i=1828492561"
                 },
                 "spotify": {
                     "id": "5oPlmrWQ9QcFvZKWFOaWW7"
@@ -19908,7 +19908,7 @@
                     "video_id": "6vzaFiMrPPY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/twilight-zone/1806193284?i=1806194571"
+                    "url": "https://geo.music.apple.com/us/album/twilight-zone/1806193284?i=1806194571"
                 },
                 "spotify": {
                     "id": "1YRbAonLvmuUILvQso0gUM"
@@ -19934,7 +19934,7 @@
                     "video_id": "Rs9w2x_zlRE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ecstatic-heads/1812679754?i=1812679924"
+                    "url": "https://geo.music.apple.com/us/album/ecstatic-heads/1812679754?i=1812679924"
                 },
                 "spotify": {
                     "id": "6h8nLmwNxWrHKYm9p28oc2"
@@ -19960,7 +19960,7 @@
                     "video_id": "LEhTlLnOVDU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wassup/1808504795?i=1808504796"
+                    "url": "https://geo.music.apple.com/us/album/wassup/1808504795?i=1808504796"
                 },
                 "spotify": {
                     "id": "32SJM4tQyJHsB8rgVtZURn"
@@ -19985,7 +19985,7 @@
                     "video_id": "mj4yh7YrwfE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/olympian/1802175271?i=1802175741"
+                    "url": "https://geo.music.apple.com/us/album/olympian/1802175271?i=1802175741"
                 },
                 "spotify": {
                     "id": "4uoADk7q83CHvXHW3k1etM"
@@ -20011,7 +20011,7 @@
                     "video_id": "OrMu3Kv-k00"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/run-run-run-pt-ii/1788296577?i=1788296933"
+                    "url": "https://geo.music.apple.com/us/album/run-run-run-pt-ii/1788296577?i=1788296933"
                 },
                 "spotify": {
                     "id": "06nhoOF0GViBt0LUWyCTNA"
@@ -20059,7 +20059,7 @@
                     "video_id": "--ZlgpBPbqQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/inept-apollo/1807891124?i=1807891125"
+                    "url": "https://geo.music.apple.com/us/album/inept-apollo/1807891124?i=1807891125"
                 },
                 "spotify": {
                     "id": "6YE0zn10XApgoCMaFeSj7b"
@@ -20085,7 +20085,7 @@
                     "video_id": "6luJVmPmzy8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/777/1802291982?i=1802291983"
+                    "url": "https://geo.music.apple.com/us/album/777/1802291982?i=1802291983"
                 },
                 "spotify": {
                     "id": "6UnNEuFWKFJuFSTemEs605"
@@ -20111,7 +20111,7 @@
                     "video_id": "oEg9AUYRZbE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/secret-city/1809421971?i=1809422075"
+                    "url": "https://geo.music.apple.com/us/album/secret-city/1809421971?i=1809422075"
                 },
                 "spotify": {
                     "id": "4H512sUGwagrnMGNoO6wmN"
@@ -20159,7 +20159,7 @@
                     "video_id": "uHdtNXkXoc4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/get-in-line/1847722952?i=1847722953"
+                    "url": "https://geo.music.apple.com/us/album/get-in-line/1847722952?i=1847722953"
                 },
                 "spotify": {
                     "id": "41oiTiyHxOFSy8dXK3pQyb"
@@ -20185,7 +20185,7 @@
                     "video_id": "yc8_dYPx4ao"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sunshine-rain/1804747038?i=1804747472"
+                    "url": "https://geo.music.apple.com/us/album/sunshine-rain/1804747038?i=1804747472"
                 },
                 "spotify": {
                     "id": "7lj0vXLgWbyB0BvCsk22hn"
@@ -20211,7 +20211,7 @@
                     "video_id": "-RJmbmydI8k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/merlot-and-grigio-feat-father-philis/1842109727?i=1842109733"
+                    "url": "https://geo.music.apple.com/us/album/merlot-and-grigio-feat-father-philis/1842109727?i=1842109733"
                 },
                 "spotify": {
                     "id": "5wlbrG0V3fuAlfLdH7EttL"
@@ -20237,7 +20237,7 @@
                     "video_id": "u5ZmvK6usc8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/postparto/1796833459?i=1796833460"
+                    "url": "https://geo.music.apple.com/us/album/postparto/1796833459?i=1796833460"
                 },
                 "spotify": {
                     "id": "4CpTehJ87nNwGCIJrSybkS"
@@ -20263,7 +20263,7 @@
                     "video_id": "iH7zvbpnCww"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/history-of-violence/1793491480?i=1793491487"
+                    "url": "https://geo.music.apple.com/us/album/history-of-violence/1793491480?i=1793491487"
                 },
                 "spotify": {
                     "id": "0RO1bV3EWlgG8atze1u0Xq"
@@ -20289,7 +20289,7 @@
                     "video_id": "n6rie3SPPJo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-largest/1791802502?i=1791802517"
+                    "url": "https://geo.music.apple.com/us/album/the-largest/1791802502?i=1791802517"
                 },
                 "spotify": {
                     "id": "3neOwym9kfYsM1QWaR77C1"
@@ -20315,7 +20315,7 @@
                     "video_id": "U-124RmcV7I"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/stranger/1834042903?i=1834042909"
+                    "url": "https://geo.music.apple.com/us/album/stranger/1834042903?i=1834042909"
                 },
                 "spotify": {
                     "id": "6IBTI6u7tVNtWojUHnO4Ap"
@@ -20341,7 +20341,7 @@
                     "video_id": "aFpfY-EZwFo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/blue-strips/1815585441?i=1815585610"
+                    "url": "https://geo.music.apple.com/us/album/blue-strips/1815585441?i=1815585610"
                 },
                 "spotify": {
                     "id": "5kUXTPwxC6ZkduukaukCRT"
@@ -20367,7 +20367,7 @@
                     "video_id": "SgZ0ZEdMzkA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/my-best-step/1817621221?i=1817621222"
+                    "url": "https://geo.music.apple.com/us/album/my-best-step/1817621221?i=1817621222"
                 },
                 "spotify": {
                     "id": "0w5t8iJ6RVCBWFgePi7uiU"
@@ -20393,7 +20393,7 @@
                     "video_id": "-6OiASeY-As"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/whats-right/1844710034?i=1844710066"
+                    "url": "https://geo.music.apple.com/us/album/whats-right/1844710034?i=1844710066"
                 },
                 "spotify": {
                     "id": "2YXDguAdOrvWYIwbPjvAkA"
@@ -20442,7 +20442,7 @@
                     "video_id": "Bc-M8lVkH7M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/scanners/1805847786?i=1805847787"
+                    "url": "https://geo.music.apple.com/us/album/scanners/1805847786?i=1805847787"
                 },
                 "spotify": {
                     "id": "5p9JMOuMlYLDtfWtzW23v6"
@@ -20468,7 +20468,7 @@
                     "video_id": "jdU16tnrt14"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/take-me-by-the-hand/1779808073?i=1779808088"
+                    "url": "https://geo.music.apple.com/us/album/take-me-by-the-hand/1779808073?i=1779808088"
                 },
                 "spotify": {
                     "id": "6Y16szIjrhu91wNbHTDqhX"
@@ -20517,7 +20517,7 @@
                     "video_id": "e2u39ZRT59U"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/act-right/1830535998?i=1830536352"
+                    "url": "https://geo.music.apple.com/us/album/act-right/1830535998?i=1830536352"
                 },
                 "spotify": {
                     "id": "1z0gNe6DiusPKN55RBAvRO"
@@ -20543,7 +20543,7 @@
                     "video_id": "k2hlr_ddpG8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/6-months-later/1820288139?i=1820288141"
+                    "url": "https://geo.music.apple.com/us/album/6-months-later/1820288139?i=1820288141"
                 },
                 "spotify": {
                     "id": "4Km9FSF9iaQiTLnFPdbPom"
@@ -20569,7 +20569,7 @@
                     "video_id": "ukae50oYzGE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/crimson-and-clay/1790456398?i=1790456406"
+                    "url": "https://geo.music.apple.com/us/album/crimson-and-clay/1790456398?i=1790456406"
                 },
                 "spotify": {
                     "id": "60gQmNkGCHQEb4TaJC9IwC"
@@ -20595,7 +20595,7 @@
                     "video_id": "Cj9K-pfBdlo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/scandinavia/1832310241?i=1832310454"
+                    "url": "https://geo.music.apple.com/us/album/scandinavia/1832310241?i=1832310454"
                 },
                 "spotify": {
                     "id": "1jHFs6W5atp1hP0EhNmaZ3"
@@ -20621,7 +20621,7 @@
                     "video_id": "mJccPYV7UGA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/salt-then-sour-then-sweet-feat-brandi-carlile/1852043650?i=1852043652"
+                    "url": "https://geo.music.apple.com/us/album/salt-then-sour-then-sweet-feat-brandi-carlile/1852043650?i=1852043652"
                 },
                 "spotify": {
                     "id": "46o2qUuuuftFaeo6yHsyI1"
@@ -20647,7 +20647,7 @@
                     "video_id": "P7yS26LVcLs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/slide-away-live-from-cardiff-4-july-25/1825458952?i=1825458953"
+                    "url": "https://geo.music.apple.com/us/album/slide-away-live-from-cardiff-4-july-25/1825458952?i=1825458953"
                 },
                 "spotify": {
                     "id": "3WFinnHQKSEhVOZmYNR0Kd"
@@ -20673,7 +20673,7 @@
                     "video_id": "jixxOkOUV40"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/davina-mccall/1802918329?i=1802918485"
+                    "url": "https://geo.music.apple.com/us/album/davina-mccall/1802918329?i=1802918485"
                 },
                 "spotify": {
                     "id": "4KVYz4U1Vm3pvjhhhS1E6s"
@@ -20699,7 +20699,7 @@
                     "video_id": "FXJ4Xs14xr0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/a-long-goodbye/1848218479?i=1848218747"
+                    "url": "https://geo.music.apple.com/us/album/a-long-goodbye/1848218479?i=1848218747"
                 },
                 "spotify": {
                     "id": "77tp1Yy4gys1k5bDtUygfu"
@@ -20725,7 +20725,7 @@
                     "video_id": "Id_0DsBctYg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cuntissimo/1807308262?i=1807308322"
+                    "url": "https://geo.music.apple.com/us/album/cuntissimo/1807308262?i=1807308322"
                 },
                 "spotify": {
                     "id": "4J1xDjTOAxqpFxaRtd4zh6"
@@ -20751,7 +20751,7 @@
                     "video_id": "T5nf0kFQddc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/getting-killed/1818548779?i=1818548787"
+                    "url": "https://geo.music.apple.com/us/album/getting-killed/1818548779?i=1818548787"
                 },
                 "spotify": {
                     "id": "4gXvwRoP7GYoipYRTXQUxW"
@@ -20777,7 +20777,7 @@
                     "video_id": "82luRiMD_Jw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/best-guess/1844471188?i=1844471596"
+                    "url": "https://geo.music.apple.com/us/album/best-guess/1844471188?i=1844471596"
                 },
                 "spotify": {
                     "id": "2u6VEZjUu5P3GVfUMDIIbu"
@@ -20803,7 +20803,7 @@
                     "video_id": "qgIVz41PfzE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/long-after-midnight/1805244167?i=1805244380"
+                    "url": "https://geo.music.apple.com/us/album/long-after-midnight/1805244167?i=1805244380"
                 },
                 "spotify": {
                     "id": "13UDyEmTT5uWXZgq1TdCFA"
@@ -20829,7 +20829,7 @@
                     "video_id": "wszWGInVWcw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/little-richards-bible/1789808691?i=1789808848"
+                    "url": "https://geo.music.apple.com/us/album/little-richards-bible/1789808691?i=1789808848"
                 },
                 "spotify": {
                     "id": "6LbH57lWaf4JrqdKYyqz6J"
@@ -20855,7 +20855,7 @@
                     "video_id": "B24si8B9C-g"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wound-up-here-by-holdin-on/1807870796?i=1807870801"
+                    "url": "https://geo.music.apple.com/us/album/wound-up-here-by-holdin-on/1807870796?i=1807870801"
                 },
                 "spotify": {
                     "id": "5b7XNPJbJV5ncuFGoh9ZJy"
@@ -20881,7 +20881,7 @@
                     "video_id": "cr4wnsLI_Xw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/2-hands/1779319620?i=1779319625"
+                    "url": "https://geo.music.apple.com/us/album/2-hands/1779319620?i=1779319625"
                 },
                 "spotify": {
                     "id": "0B7tnohfi83RQquo2JRHrL"
@@ -20907,7 +20907,7 @@
                     "video_id": "sMndhNF-nyI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/party-people/1848256074?i=1848256284"
+                    "url": "https://geo.music.apple.com/us/album/party-people/1848256074?i=1848256284"
                 },
                 "spotify": {
                     "id": "0KN08YO4zGw8NCkCiaRkS9"
@@ -20933,7 +20933,7 @@
                     "video_id": "0lmzkhGoRr4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/love-forever/1825083551?i=1825083936"
+                    "url": "https://geo.music.apple.com/us/album/love-forever/1825083551?i=1825083936"
                 },
                 "spotify": {
                     "id": "74Ya4KTyVdBkKn0grWGyDj"
@@ -20959,7 +20959,7 @@
                     "video_id": "zCpB1GS6gR4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ocean-city/1829014969?i=1829014971"
+                    "url": "https://geo.music.apple.com/us/album/ocean-city/1829014969?i=1829014971"
                 },
                 "spotify": {
                     "id": "6di4zDK4P0M904AjR4aVDx"
@@ -20985,7 +20985,7 @@
                     "video_id": "Xxm7mgSgV0Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/piece-of-mind/1821219177?i=1821219454"
+                    "url": "https://geo.music.apple.com/us/album/piece-of-mind/1821219177?i=1821219454"
                 },
                 "spotify": {
                     "id": "4Cc8WY4SZ8gYTx8aYYN96l"
@@ -21011,7 +21011,7 @@
                     "video_id": "jGcvOP9BB3k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/monica-lewinskibidi/1812498358?i=1812498366"
+                    "url": "https://geo.music.apple.com/us/album/monica-lewinskibidi/1812498358?i=1812498366"
                 },
                 "spotify": {
                     "id": "1iecQAfm1L6eoTnvxLEN61"
@@ -21037,7 +21037,7 @@
                     "video_id": "cfhRITCzKGE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/go-baby/1825994646?i=1825994653"
+                    "url": "https://geo.music.apple.com/us/album/go-baby/1825994646?i=1825994653"
                 },
                 "spotify": {
                     "id": "01p5urrGw5fuFCcfT7PBgc"
@@ -21063,7 +21063,7 @@
                     "video_id": "TJgFCSCyMiM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/fly/1784548523?i=1784548524"
+                    "url": "https://geo.music.apple.com/us/album/fly/1784548523?i=1784548524"
                 },
                 "spotify": {
                     "id": "7rpKFFRgEFbFD0H5SkiLfg"
@@ -21089,7 +21089,7 @@
                     "video_id": "FhNM3Fl857c"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/memphis-the-blues-feat-j-r-carroll/1819829616?i=1819830113"
+                    "url": "https://geo.music.apple.com/us/album/memphis-the-blues-feat-j-r-carroll/1819829616?i=1819830113"
                 },
                 "spotify": {
                     "id": "3lXyvlMnee9RWoe0COt7S4"
@@ -21115,7 +21115,7 @@
                     "video_id": "MHs7DQ1WnYo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bugland/1807902202?i=1807902218"
+                    "url": "https://geo.music.apple.com/us/album/bugland/1807902202?i=1807902218"
                 },
                 "spotify": {
                     "id": "1D6d3Yp27FQdxLD8b4iudy"
@@ -21141,7 +21141,7 @@
                     "video_id": "aOxLuZO4uuE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-way-love-goes/1807870796?i=1807870810"
+                    "url": "https://geo.music.apple.com/us/album/the-way-love-goes/1807870796?i=1807870810"
                 },
                 "spotify": {
                     "id": "1o9KFXJkF6jBpIvd4rthsi"
@@ -21167,7 +21167,7 @@
                     "video_id": "jT76NaBzj1Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/payroll-feat-xpert-productions/1814686367?i=1814686369"
+                    "url": "https://geo.music.apple.com/us/album/payroll-feat-xpert-productions/1814686367?i=1814686369"
                 },
                 "spotify": {
                     "id": "3XTjtCEfZ34xMua70IK01m"
@@ -21193,7 +21193,7 @@
                     "video_id": "xIq2YblrBrQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/past-lives-feat-hayley-williams/1817547215?i=1817547216"
+                    "url": "https://geo.music.apple.com/us/album/past-lives-feat-hayley-williams/1817547215?i=1817547216"
                 },
                 "spotify": {
                     "id": "4p3ZHnh9AJuZeyJ93WooeI"
@@ -21219,7 +21219,7 @@
                     "video_id": "eOi9ipB5yo0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/country-girl/1804151130?i=1804151353"
+                    "url": "https://geo.music.apple.com/us/album/country-girl/1804151130?i=1804151353"
                 },
                 "spotify": {
                     "id": "2nMyXK7jOtqyeCLkgBmTvN"
@@ -21245,7 +21245,7 @@
                     "video_id": "RyKa_qFfuqc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/buschtaxi/1785179804?i=1785182044"
+                    "url": "https://geo.music.apple.com/us/album/buschtaxi/1785179804?i=1785182044"
                 },
                 "spotify": {
                     "id": "6Z4AJ6GVRjdjmbm4TK1Wca"
@@ -21271,7 +21271,7 @@
                     "video_id": "OglxJ33ITxA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/luckiest-man-alive/1805187207?i=1805187215"
+                    "url": "https://geo.music.apple.com/us/album/luckiest-man-alive/1805187207?i=1805187215"
                 },
                 "spotify": {
                     "id": "4VJQplLkX6agarX99u0iDm"
@@ -21297,7 +21297,7 @@
                     "video_id": "e9ARHZyv-Y0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/angus-valley/1826608336?i=1826608338"
+                    "url": "https://geo.music.apple.com/us/album/angus-valley/1826608336?i=1826608338"
                 },
                 "spotify": {
                     "id": "5JhA03j2Sg0ySVXCL5XwCi"
@@ -21345,7 +21345,7 @@
                     "video_id": "qB7kLilZWwg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/somebody/1813906511?i=1813906513"
+                    "url": "https://geo.music.apple.com/us/album/somebody/1813906511?i=1813906513"
                 },
                 "spotify": {
                     "id": "1GpslorH7Gi64x8uodyvfO"
@@ -21371,7 +21371,7 @@
                     "video_id": "D4Ggz6oShaI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/killah/1837310866?i=1837310876"
+                    "url": "https://geo.music.apple.com/us/album/killah/1837310866?i=1837310876"
                 },
                 "spotify": {
                     "id": "4pNzBbGcqXofx8mLBPTeih"
@@ -21420,7 +21420,7 @@
                     "video_id": "VuxfsrVs0ME"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/good-while-it-lasted/1790456398?i=1790456408"
+                    "url": "https://geo.music.apple.com/us/album/good-while-it-lasted/1790456398?i=1790456408"
                 },
                 "spotify": {
                     "id": "3URnvhDLXtkLegFuTZHRcz"
@@ -21446,7 +21446,7 @@
                     "video_id": "fJDAMBOY9Ig"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/coast/1843397459?i=1843397460"
+                    "url": "https://geo.music.apple.com/us/album/coast/1843397459?i=1843397460"
                 },
                 "spotify": {
                     "id": "51qSkFx8D2dyWERxGQ44My"
@@ -21472,7 +21472,7 @@
                     "video_id": "j25UUnotr7o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/catching-feelings/1819900602?i=1819900608"
+                    "url": "https://geo.music.apple.com/us/album/catching-feelings/1819900602?i=1819900608"
                 },
                 "spotify": {
                     "id": "5WZL03aLF9GVNaa5Q6ATNe"
@@ -21498,7 +21498,7 @@
                     "video_id": "4Ccgd5MT9s4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-sit-in-parks/1853638193?i=1853638205"
+                    "url": "https://geo.music.apple.com/us/album/i-sit-in-parks/1853638193?i=1853638205"
                 },
                 "spotify": {
                     "id": "35OvmPX96d7f1ElQMl8Pq2"
@@ -21524,7 +21524,7 @@
                     "video_id": "MbJ72KO5khs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/run-it-up/1827126547?i=1827126552"
+                    "url": "https://geo.music.apple.com/us/album/run-it-up/1827126547?i=1827126552"
                 },
                 "spotify": {
                     "id": "3sZQ8L4aptFDJXBqdVdvO8"
@@ -21550,7 +21550,7 @@
                     "video_id": "Mk2EWJpIILM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/holy-visions/1824013544?i=1824013549"
+                    "url": "https://geo.music.apple.com/us/album/holy-visions/1824013544?i=1824013549"
                 },
                 "spotify": {
                     "id": "5DcTkTG3Z4uoQTxIv4LgPZ"
@@ -21576,7 +21576,7 @@
                     "video_id": "HJimA76vg3k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/special-request-to-all-nice-and-decent-real-n-z-stop-hatin/1800910305?i=1800910306"
+                    "url": "https://geo.music.apple.com/us/album/special-request-to-all-nice-and-decent-real-n-z-stop-hatin/1800910305?i=1800910306"
                 },
                 "spotify": {
                     "id": "0V8TG3xjxM9IrBK2EMrCny"
@@ -21605,7 +21605,7 @@
                     "video_id": "z7-bDzJbtis"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/loco/1785305535?i=1785305536"
+                    "url": "https://geo.music.apple.com/us/album/loco/1785305535?i=1785305536"
                 },
                 "spotify": {
                     "id": "4eLDmhsJW3JoZTXCAozHor"
@@ -21631,7 +21631,7 @@
                     "video_id": "lb2Wpz9UkIs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/furry-sings-the-blues-unplugged/1786427369?i=1786427377"
+                    "url": "https://geo.music.apple.com/us/album/furry-sings-the-blues-unplugged/1786427369?i=1786427377"
                 },
                 "spotify": {
                     "id": "5DbsGLA9hVVclF8g6KWYai"
@@ -21657,7 +21657,7 @@
                     "video_id": "i1_u1OSu4JI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/burning-moonlight/1792208208?i=1792208390"
+                    "url": "https://geo.music.apple.com/us/album/burning-moonlight/1792208208?i=1792208390"
                 },
                 "spotify": {
                     "id": "5uXpQh7y6pqwoEbPgmjXCu"
@@ -21683,7 +21683,7 @@
                     "video_id": "um7z-C6weOA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bug/1836334709?i=1836334718"
+                    "url": "https://geo.music.apple.com/us/album/bug/1836334709?i=1836334718"
                 },
                 "spotify": {
                     "id": "5ZMx3OaX3quw7BlSt3dUZa"
@@ -21709,7 +21709,7 @@
                     "video_id": "6ozf7b1QoXA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/westerberg-feat-eva-tolkin-liam-benzvi/1825903903?i=1825904370"
+                    "url": "https://geo.music.apple.com/us/album/westerberg-feat-eva-tolkin-liam-benzvi/1825903903?i=1825904370"
                 },
                 "spotify": {
                     "id": "0wew10FuXHnhlSmLXUpWdt"
@@ -21735,7 +21735,7 @@
                     "video_id": "ZNrQZ82e83o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/star-of-hope/1788958413?i=1788958690"
+                    "url": "https://geo.music.apple.com/us/album/star-of-hope/1788958413?i=1788958690"
                 },
                 "spotify": {
                     "id": "018flP7rUxOYjiccV8czwy"
@@ -21761,7 +21761,7 @@
                     "video_id": "RMtk0kb3q7M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lost-in-translation/1832081483?i=1832081484"
+                    "url": "https://geo.music.apple.com/us/album/lost-in-translation/1832081483?i=1832081484"
                 },
                 "spotify": {
                     "id": "2DQ4xJf4xm1Ho8yKQkOqgi"
@@ -21787,7 +21787,7 @@
                     "video_id": "kLSu3NGHQG0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/melodie-is-a-wound/1805581599?i=1805581600"
+                    "url": "https://geo.music.apple.com/us/album/melodie-is-a-wound/1805581599?i=1805581600"
                 },
                 "spotify": {
                     "id": "1qCOC3y2zuswTq6PZoL2ID"
@@ -21813,7 +21813,7 @@
                     "video_id": "-JAtwolReQg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/good-news/1811448288?i=1811449012"
+                    "url": "https://geo.music.apple.com/us/album/good-news/1811448288?i=1811449012"
                 },
                 "spotify": {
                     "id": "5VHRiH48pBB008CAkrIBwP"
@@ -21839,7 +21839,7 @@
                     "video_id": "b-H-kCpAejw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/understand-feat-curren%24y/1834279202?i=1834279205"
+                    "url": "https://geo.music.apple.com/us/album/understand-feat-curren%24y/1834279202?i=1834279205"
                 },
                 "spotify": {
                     "id": "2QE1HicP9V1gI9QY6eOCTu"
@@ -21865,7 +21865,7 @@
                     "video_id": "fgVkE1Jd8pc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lamp-fall/1808024244?i=1808024254"
+                    "url": "https://geo.music.apple.com/us/album/lamp-fall/1808024244?i=1808024254"
                 },
                 "spotify": {
                     "id": "6HybzXJc5MO4GDfNuZIVcS"
@@ -21891,7 +21891,7 @@
                     "video_id": "gFzs8YJuAbE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/my-co-worker-clark-kents-secret-black-box/1822567348?i=1822567616"
+                    "url": "https://geo.music.apple.com/us/album/my-co-worker-clark-kents-secret-black-box/1822567348?i=1822567616"
                 },
                 "spotify": {
                     "id": "4l8t27aV3hDR55Dv7Nx7UX"
@@ -21917,7 +21917,7 @@
                     "video_id": "dixyMxnPuoA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/high-horse/1799674112?i=1799674116"
+                    "url": "https://geo.music.apple.com/us/album/high-horse/1799674112?i=1799674116"
                 },
                 "spotify": {
                     "id": "2YUUYGB1kMtXKTQ6ajAjTA"
@@ -21942,7 +21942,7 @@
                     "video_id": "jq-L70UXun8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/takedown/1861566321?i=1861566854"
+                    "url": "https://geo.music.apple.com/us/album/takedown/1861566321?i=1861566854"
                 },
                 "spotify": {
                     "id": "0MHStU0muAIEMbwdnebYu2"
@@ -21968,7 +21968,7 @@
                     "video_id": "6oJkXrNYBA4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-aint-comin-back/1802103958?i=1802104420"
+                    "url": "https://geo.music.apple.com/us/album/i-aint-comin-back/1802103958?i=1802104420"
                 },
                 "spotify": {
                     "id": "1BDLD4c07q0bmq2VCRsXoE"
@@ -21994,7 +21994,7 @@
                     "video_id": "bIDRLLVaLlQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/how-does-it-feel/1820029400?i=1820029404"
+                    "url": "https://geo.music.apple.com/us/album/how-does-it-feel/1820029400?i=1820029404"
                 },
                 "spotify": {
                     "id": "4SNPg0KDZ859vauVTaNg7i"
@@ -22020,7 +22020,7 @@
                     "video_id": "P3D5VsDTdjg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/just-how-you-are/1842203086?i=1842203087"
+                    "url": "https://geo.music.apple.com/us/album/just-how-you-are/1842203086?i=1842203087"
                 },
                 "spotify": {
                     "id": "7KO0PWYRvoQMNdOZ4KHulW"
@@ -22046,7 +22046,7 @@
                     "video_id": "Be7U0X9KKZE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/environmental-catastrophe-film/1811680398?i=1811680612"
+                    "url": "https://geo.music.apple.com/us/album/environmental-catastrophe-film/1811680398?i=1811680612"
                 },
                 "spotify": {
                     "id": "265oUq9rH0eV03CmMV0vmA"
@@ -22072,7 +22072,7 @@
                     "video_id": "_0oAUs36GWI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pop-punk-anthem-sorry-for-the-delay/1854883459?i=1854883470"
+                    "url": "https://geo.music.apple.com/us/album/pop-punk-anthem-sorry-for-the-delay/1854883459?i=1854883470"
                 },
                 "spotify": {
                     "id": "55JAgc5FHJNW5WvNAFzBcW"
@@ -22098,7 +22098,7 @@
                     "video_id": "p2DZa3V5CQo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/oganesson/1835037085?i=1835037094"
+                    "url": "https://geo.music.apple.com/us/album/oganesson/1835037085?i=1835037094"
                 },
                 "spotify": {
                     "id": "4AeEJMj92wcssAFjPLtVMY"
@@ -22147,7 +22147,7 @@
                     "video_id": "V8Oa2DNFBsE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/groucho-marks/1825216752?i=1825217157"
+                    "url": "https://geo.music.apple.com/us/album/groucho-marks/1825216752?i=1825217157"
                 },
                 "spotify": {
                     "id": "1td8l5TOZLYUS6znwstHcL"
@@ -22173,7 +22173,7 @@
                     "video_id": "DyvG1lMP6zk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ok-but-im-the-phone-screen/1817665332?i=1817665558"
+                    "url": "https://geo.music.apple.com/us/album/ok-but-im-the-phone-screen/1817665332?i=1817665558"
                 },
                 "spotify": {
                     "id": "3PfA2PM8z6iO36CPOi7CHq"
@@ -22199,7 +22199,7 @@
                     "video_id": "rNhLzr-OlWo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/vegetation-grows-thick/1810825371?i=1810825372"
+                    "url": "https://geo.music.apple.com/us/album/vegetation-grows-thick/1810825371?i=1810825372"
                 },
                 "spotify": {
                     "id": "0Poy6PuvK8nrHDjkTtVusT"
@@ -22225,7 +22225,7 @@
                     "video_id": "SOS95RuMnIA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/don-enzo-magic-carpet-salesman/1843636380?i=1843636391"
+                    "url": "https://geo.music.apple.com/us/album/don-enzo-magic-carpet-salesman/1843636380?i=1843636391"
                 },
                 "spotify": {
                     "id": "1uaDFdd8tYV7m4EWH4Xq9l"
@@ -22251,7 +22251,7 @@
                     "video_id": "u0TqWGxSsBY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/carrossel/1801634375?i=1801634376"
+                    "url": "https://geo.music.apple.com/us/album/carrossel/1801634375?i=1801634376"
                 },
                 "spotify": {
                     "id": "3RC1QgJh7sFaWkFdFJMGS6"
@@ -22277,7 +22277,7 @@
                     "video_id": "gEZ0PNK8tSM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/honey-water/1785246760?i=1785246766"
+                    "url": "https://geo.music.apple.com/us/album/honey-water/1785246760?i=1785246766"
                 },
                 "spotify": {
                     "id": "5JVEWVNVv8OYILCkHZkwvK"
@@ -22326,7 +22326,7 @@
                     "video_id": "KlvN4h1tgZI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/babe-iii/1834178437?i=1834178438"
+                    "url": "https://geo.music.apple.com/us/album/babe-iii/1834178437?i=1834178438"
                 },
                 "spotify": {
                     "id": "0D9gTE3I7vhTdxyIgLTkJC"
@@ -22352,7 +22352,7 @@
                     "video_id": "eUTUXAeSpqE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hammer/1810905299?i=1810905304"
+                    "url": "https://geo.music.apple.com/us/album/hammer/1810905299?i=1810905304"
                 },
                 "spotify": {
                     "id": "01U0X0ToQhK0AgvNUdyXQe"
@@ -22378,7 +22378,7 @@
                     "video_id": "rE-4FDZnXDw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bad-state-of-mind/1794671363?i=1794671371"
+                    "url": "https://geo.music.apple.com/us/album/bad-state-of-mind/1794671363?i=1794671371"
                 },
                 "spotify": {
                     "id": "01QN0DfaIrazVmGEfZ5RVX"
@@ -22404,7 +22404,7 @@
                     "video_id": "iERTgcKCO4Q"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/death-of-the-party/1811815005?i=1811815488"
+                    "url": "https://geo.music.apple.com/us/album/death-of-the-party/1811815005?i=1811815488"
                 },
                 "spotify": {
                     "id": "5YZyIjrHPtmJBTBzauiH0Z"
@@ -22430,7 +22430,7 @@
                     "video_id": "SesxWJaEhAA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/83/1801745441?i=1801745445"
+                    "url": "https://geo.music.apple.com/us/album/83/1801745441?i=1801745445"
                 },
                 "spotify": {
                     "id": "7wbGNuUZLrnzT0XpEuIw4g"
@@ -22456,7 +22456,7 @@
                     "video_id": "w7pjt9ZH3NM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/la-perla/1848167516?i=1848167530"
+                    "url": "https://geo.music.apple.com/us/album/la-perla/1848167516?i=1848167530"
                 },
                 "spotify": {
                     "id": "4oVO4fGNRRvEn0CRuFO4qv"
@@ -22482,7 +22482,7 @@
                     "video_id": "52ubMoqxZaI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hawk/1824654330?i=1824654333"
+                    "url": "https://geo.music.apple.com/us/album/hawk/1824654330?i=1824654333"
                 },
                 "spotify": {
                     "id": "5cvcTqLPUWGsJSz2m8GGeP"
@@ -22508,7 +22508,7 @@
                     "video_id": "G2vm5djpUgo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/full-moon-feat-weird-nightmare/1819523324?i=1819523636"
+                    "url": "https://geo.music.apple.com/us/album/full-moon-feat-weird-nightmare/1819523324?i=1819523636"
                 },
                 "spotify": {
                     "id": "1nZDh3rmby6PXE7aDRsKTU"
@@ -22534,7 +22534,7 @@
                     "video_id": "SEdZ3tfC6_E"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ali-bomaye/1789437584?i=1789437587"
+                    "url": "https://geo.music.apple.com/us/album/ali-bomaye/1789437584?i=1789437587"
                 },
                 "spotify": {
                     "id": "0jaMR6KQ1voR8RHlZ7Pg4G"
@@ -22582,7 +22582,7 @@
                     "video_id": "aEcAyxfbHbQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/outside/1826817033?i=1826817702"
+                    "url": "https://geo.music.apple.com/us/album/outside/1826817033?i=1826817702"
                 },
                 "spotify": {
                     "id": "139nLHDFZNr3anx8CpUy7u"
@@ -22608,7 +22608,7 @@
                     "video_id": "tgq8I1CduH8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/all-the-good-men/1823285424?i=1823285434"
+                    "url": "https://geo.music.apple.com/us/album/all-the-good-men/1823285424?i=1823285434"
                 },
                 "spotify": {
                     "id": "1lHsjpIJ9aFOkz4w4yduzt"
@@ -22634,7 +22634,7 @@
                     "video_id": "4DXQaz_bRrg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lord-bateman/1822385170?i=1822385186"
+                    "url": "https://geo.music.apple.com/us/album/lord-bateman/1822385170?i=1822385186"
                 },
                 "spotify": {
                     "id": "33R1gmtNjLE1irIgiOCReb"
@@ -22660,7 +22660,7 @@
                     "video_id": "OkktfeAR-Rk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/worst-way/1861871286?i=1861871296"
+                    "url": "https://geo.music.apple.com/us/album/worst-way/1861871286?i=1861871296"
                 },
                 "spotify": {
                     "id": "1osfLqL6L2iQsirRf83ded"
@@ -22709,7 +22709,7 @@
                     "video_id": "oe1154JNsok"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mystical-magical/1836175512?i=1836176074"
+                    "url": "https://geo.music.apple.com/us/album/mystical-magical/1836175512?i=1836176074"
                 },
                 "spotify": {
                     "id": "2ipIPsgrgd0j2beDf4Ki70"
@@ -22735,7 +22735,7 @@
                     "video_id": "QRRUXq0rvmg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/come-over/1799278610?i=1799278622"
+                    "url": "https://geo.music.apple.com/us/album/come-over/1799278610?i=1799278622"
                 },
                 "spotify": {
                     "id": "1tI8Ubt5VEMWDoGL08pomF"
@@ -22761,7 +22761,7 @@
                     "video_id": "EMcqAt0zI-w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/flea/1821247551?i=1821247553"
+                    "url": "https://geo.music.apple.com/us/album/flea/1821247551?i=1821247553"
                 },
                 "spotify": {
                     "id": "5bYuSXpSeoXfrrZh3hjlG1"
@@ -22787,7 +22787,7 @@
                     "video_id": "t5mqIjdxkjQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/firing-line/1823117018?i=1823117019"
+                    "url": "https://geo.music.apple.com/us/album/firing-line/1823117018?i=1823117019"
                 },
                 "spotify": {
                     "id": "0JeZ5I1tRCVR3cnZ9FGYP8"
@@ -22813,7 +22813,7 @@
                     "video_id": "46nmXNBn9_k"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/aint-quite-right/1852384437?i=1852384442"
+                    "url": "https://geo.music.apple.com/us/album/aint-quite-right/1852384437?i=1852384442"
                 },
                 "spotify": {
                     "id": "0px4JlY1xjxoKqznyD4IPC"
@@ -22839,7 +22839,7 @@
                     "video_id": "utdozXijtvk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/po-box-96/1777262989?i=1777263008"
+                    "url": "https://geo.music.apple.com/us/album/po-box-96/1777262989?i=1777263008"
                 },
                 "spotify": {
                     "id": "0fumix9cQVECmKsSbHWw58"
@@ -22865,7 +22865,7 @@
                     "video_id": "du741727VFQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/im-your-man/1834715016?i=1834715019"
+                    "url": "https://geo.music.apple.com/us/album/im-your-man/1834715016?i=1834715019"
                 },
                 "spotify": {
                     "id": "3uzkpsb3PqPz0KoVOV99no"
@@ -22891,7 +22891,7 @@
                     "video_id": "qaOhaLvniAk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cops-robbers/1837402685?i=1837402691"
+                    "url": "https://geo.music.apple.com/us/album/cops-robbers/1837402685?i=1837402691"
                 },
                 "spotify": {
                     "id": "1adLrnw5jTY7BOJXuRoG0g"
@@ -22917,7 +22917,7 @@
                     "video_id": "lgu4VdjdLmI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-prize/1778229552?i=1778229557"
+                    "url": "https://geo.music.apple.com/us/album/the-prize/1778229552?i=1778229557"
                 },
                 "spotify": {
                     "id": "2ytshALEfnlzn9xV08Q9pD"
@@ -22943,7 +22943,7 @@
                     "video_id": "Dvp5mSVs3Cs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dodger/1776992430?i=1776992440"
+                    "url": "https://geo.music.apple.com/us/album/dodger/1776992430?i=1776992440"
                 },
                 "spotify": {
                     "id": "1tlfzZlpVMLXhkEFL4bh7Z"
@@ -22969,7 +22969,7 @@
                     "video_id": "Cq0jaj-eocI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/el-d%C3%ADa-del-amigo/1797880735?i=1797880741"
+                    "url": "https://geo.music.apple.com/us/album/el-d%C3%ADa-del-amigo/1797880735?i=1797880741"
                 },
                 "spotify": {
                     "id": "74eICpWmMuVmBtaOr3YqPN"
@@ -23018,7 +23018,7 @@
                     "video_id": "HIV3sEJmIZ0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/you-cant-always-get-what-you-want/1810025525?i=1810025531"
+                    "url": "https://geo.music.apple.com/us/album/you-cant-always-get-what-you-want/1810025525?i=1810025531"
                 },
                 "spotify": {
                     "id": "0loAUwPeBd9LvYtnaKpoGG"
@@ -23067,7 +23067,7 @@
                     "video_id": "i-WWg2zA9s0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-light-wont-shine-forever/1776023343?i=1776023887"
+                    "url": "https://geo.music.apple.com/us/album/the-light-wont-shine-forever/1776023343?i=1776023887"
                 },
                 "spotify": {
                     "id": "5ueFHJVZSCptDmR8Re9yOT"
@@ -23093,7 +23093,7 @@
                     "video_id": "Y7o0NlO5uUI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tit-for-tat/1841725869?i=1841725870"
+                    "url": "https://geo.music.apple.com/us/album/tit-for-tat/1841725869?i=1841725870"
                 },
                 "spotify": {
                     "id": "04a44cx2PJthIbN2aLMXhl"
@@ -23119,7 +23119,7 @@
                     "video_id": "lMq5F2S-5HY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/potion/1837525420?i=1837526231"
+                    "url": "https://geo.music.apple.com/us/album/potion/1837525420?i=1837526231"
                 },
                 "spotify": {
                     "id": "60jK1IQ31TzqtL1e0sHHda"
@@ -23145,7 +23145,7 @@
                     "video_id": "IPMj1dsp5sU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lighthouse/1784232304?i=1784232312"
+                    "url": "https://geo.music.apple.com/us/album/lighthouse/1784232304?i=1784232312"
                 },
                 "spotify": {
                     "id": "76EPmtvdLUdH3ODgiwEjo4"
@@ -23171,7 +23171,7 @@
                     "video_id": "SkHi6ZpDxo8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/amethyst/1792077173?i=1792077180"
+                    "url": "https://geo.music.apple.com/us/album/amethyst/1792077173?i=1792077180"
                 },
                 "spotify": {
                     "id": "3zdMs3UPyhMUCmXOsbFzQ7"
@@ -23197,7 +23197,7 @@
                     "video_id": "SXKlPP87zps"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wouldnt-let-you-realise/1786639745?i=1786639756"
+                    "url": "https://geo.music.apple.com/us/album/wouldnt-let-you-realise/1786639745?i=1786639756"
                 },
                 "spotify": {
                     "id": "7hpY7YGpDLMHQZOZYd52Vl"
@@ -23246,7 +23246,7 @@
                     "video_id": "vaqHcZwlVQM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dont-you-worry-baby-feat-madison-mcferrin/1827715784?i=1827715799"
+                    "url": "https://geo.music.apple.com/us/album/dont-you-worry-baby-feat-madison-mcferrin/1827715784?i=1827715799"
                 },
                 "spotify": {
                     "id": "45mVT3DCE7AATXgESSdfee"
@@ -23298,7 +23298,7 @@
                     "video_id": "1FT1_HWq1yI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/safeword/1797593823?i=1797593824"
+                    "url": "https://geo.music.apple.com/us/album/safeword/1797593823?i=1797593824"
                 },
                 "spotify": {
                     "id": "0rgwADAHd21s1OE7RPFwPN"
@@ -23324,7 +23324,7 @@
                     "video_id": "yTupStvbYh0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/pretty-eyes-lorraine/1795086992?i=1795087349"
+                    "url": "https://geo.music.apple.com/us/album/pretty-eyes-lorraine/1795086992?i=1795087349"
                 },
                 "spotify": {
                     "id": "0sLPXoUB1Q1gQcs1OOYy49"
@@ -23350,7 +23350,7 @@
                     "video_id": "qjCtsGcOcHM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/villain/1797843755?i=1797843758"
+                    "url": "https://geo.music.apple.com/us/album/villain/1797843755?i=1797843758"
                 },
                 "spotify": {
                     "id": "0sUJVa3AFcEqdy11QtiZCY"
@@ -23376,7 +23376,7 @@
                     "video_id": "ynrtgijC0pc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bonnet-of-pins/1797156533?i=1797156542"
+                    "url": "https://geo.music.apple.com/us/album/bonnet-of-pins/1797156533?i=1797156542"
                 },
                 "spotify": {
                     "id": "2TqQMPjKGzaZUcuLBCkuL2"
@@ -23402,7 +23402,7 @@
                     "video_id": "05xkiGF3guA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-never-lie/1728076787?i=1728077717"
+                    "url": "https://geo.music.apple.com/us/album/i-never-lie/1728076787?i=1728077717"
                 },
                 "spotify": {
                     "id": "3t6gUcGYLrUuqwpXjOFWQc"
@@ -23428,7 +23428,7 @@
                     "video_id": "F-skHFcGEio"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/kratom-headache-girls-night/1802703408?i=1802703409"
+                    "url": "https://geo.music.apple.com/us/album/kratom-headache-girls-night/1802703408?i=1802703409"
                 },
                 "spotify": {
                     "id": "2QNzWVqj2YWd8ZuBY7KZeA"
@@ -23454,7 +23454,7 @@
                     "video_id": "J-k3xa0YYU0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/thats-gonna-leave-a-mark/1813516732?i=1813516738"
+                    "url": "https://geo.music.apple.com/us/album/thats-gonna-leave-a-mark/1813516732?i=1813516738"
                 },
                 "spotify": {
                     "id": "3kz5XjngoS57hV9rU2gRH6"
@@ -23480,7 +23480,7 @@
                     "video_id": "gxpuuNqoY-s"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/artist-of-the-century/1788674268?i=1788674454"
+                    "url": "https://geo.music.apple.com/us/album/artist-of-the-century/1788674268?i=1788674454"
                 },
                 "spotify": {
                     "id": "0IRtsYqlZrATSdxuRS90Ip"
@@ -23506,7 +23506,7 @@
                     "video_id": "WnIPlMZf_Ik"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/love-is/1843645122?i=1843645137"
+                    "url": "https://geo.music.apple.com/us/album/love-is/1843645122?i=1843645137"
                 },
                 "spotify": {
                     "id": "7zuTE1Eah3KFnYb6ybC1dB"
@@ -23532,7 +23532,7 @@
                     "video_id": "Px6ivXxa39w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bethany/1785690857?i=1785690984"
+                    "url": "https://geo.music.apple.com/us/album/bethany/1785690857?i=1785690984"
                 },
                 "spotify": {
                     "id": "2DLZwV6ZyP8wuECN7UjD4Z"
@@ -23558,7 +23558,7 @@
                     "video_id": "Q8TFOBdXZj0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lover-girl/1834263082?i=1834263089"
+                    "url": "https://geo.music.apple.com/us/album/lover-girl/1834263082?i=1834263089"
                 },
                 "spotify": {
                     "id": "4nwjvcUjV7cexhwA40Bh5i"
@@ -23584,7 +23584,7 @@
                     "video_id": "Z_GcyPhhtIo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/whatx2/1803753628?i=1803753632"
+                    "url": "https://geo.music.apple.com/us/album/whatx2/1803753628?i=1803753632"
                 },
                 "spotify": {
                     "id": "6NBiRxb2ydIWmlFuuxpOhW"
@@ -23610,7 +23610,7 @@
                     "video_id": "711pKH7xZ4A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/no-loss-no-love/1779147456?i=1779147896"
+                    "url": "https://geo.music.apple.com/us/album/no-loss-no-love/1779147456?i=1779147896"
                 },
                 "spotify": {
                     "id": "2wwxE7Ww8UfcDtXCiLlnsB"
@@ -23636,7 +23636,7 @@
                     "video_id": "Qt0M2qwdVOA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/trippin-on-a-yacht-feat-bay-swag-rob49/1824313787?i=1824313790"
+                    "url": "https://geo.music.apple.com/us/album/trippin-on-a-yacht-feat-bay-swag-rob49/1824313787?i=1824313790"
                 },
                 "spotify": {
                     "id": "2oINmoPkPxKc2QATOiA0u9"
@@ -23685,7 +23685,7 @@
                     "video_id": "gl-r2iqZ5d8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/crucified-son/1822919638?i=1822919646"
+                    "url": "https://geo.music.apple.com/us/album/crucified-son/1822919638?i=1822919646"
                 },
                 "spotify": {
                     "id": "6GniZoAv7dAL3djoMjxVZa"
@@ -23711,7 +23711,7 @@
                     "video_id": "6RcW8HWM44w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/triple-lavada/1805037511?i=1805037512"
+                    "url": "https://geo.music.apple.com/us/album/triple-lavada/1805037511?i=1805037512"
                 },
                 "spotify": {
                     "id": "6uroNiDEDd0xFLiri0aQNk"
@@ -23737,7 +23737,7 @@
                     "video_id": "Ytmcwjf2amw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/your-idol/1820264137?i=1820264156"
+                    "url": "https://geo.music.apple.com/us/album/your-idol/1820264137?i=1820264156"
                 },
                 "spotify": {
                     "id": "1I37Zz2g3hk9eWxaNkj031"
@@ -23763,7 +23763,7 @@
                     "video_id": "d2BccxyPZcM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/kermit-gyro/1778094679?i=1778094680"
+                    "url": "https://geo.music.apple.com/us/album/kermit-gyro/1778094679?i=1778094680"
                 },
                 "spotify": {
                     "id": "1HaNDMAJjsEinenk205n4P"
@@ -23789,7 +23789,7 @@
                     "video_id": "_GwXG95Gcq4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/back-again/1764996083?i=1764996095"
+                    "url": "https://geo.music.apple.com/us/album/back-again/1764996083?i=1764996095"
                 },
                 "spotify": {
                     "id": "0kFv6QchgZrrbd7mPP5QrU"
@@ -23815,7 +23815,7 @@
                     "video_id": "0hm03E3NQlU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mud/1790581476?i=1790581477"
+                    "url": "https://geo.music.apple.com/us/album/mud/1790581476?i=1790581477"
                 },
                 "spotify": {
                     "id": "7leOfpblnwIyAqr2u4hNZE"
@@ -23841,7 +23841,7 @@
                     "video_id": "AIk4EoNcGvE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/destination/1820224734?i=1820224735"
+                    "url": "https://geo.music.apple.com/us/album/destination/1820224734?i=1820224735"
                 },
                 "spotify": {
                     "id": "5BlGwkHjJHXa7ssaElVmYt"
@@ -23867,7 +23867,7 @@
                     "video_id": "m-lQzTpk_cM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dear-time-feat-jackson-browne-with-jeff-hanna/1833577066?i=1833577067"
+                    "url": "https://geo.music.apple.com/us/album/dear-time-feat-jackson-browne-with-jeff-hanna/1833577066?i=1833577067"
                 },
                 "spotify": {
                     "id": "5S9Fp2B0AOyURvKnnNRuQe"
@@ -23893,7 +23893,7 @@
                     "video_id": "r8m_JPSWwME"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wet-faced-ugly/1785627670?i=1785627881"
+                    "url": "https://geo.music.apple.com/us/album/wet-faced-ugly/1785627670?i=1785627881"
                 },
                 "spotify": {
                     "id": "3yAVjo24bbVBElLDlIO4fv"
@@ -23919,7 +23919,7 @@
                     "video_id": "vx_jOvSVqIY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/teteo-in-the-bronx/1848369424?i=1848369425"
+                    "url": "https://geo.music.apple.com/us/album/teteo-in-the-bronx/1848369424?i=1848369425"
                 },
                 "spotify": {
                     "id": "53gZyaUBzGwLyUKDc3sdJQ"
@@ -23945,7 +23945,7 @@
                     "video_id": "TR19QSL7WuQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ordinary/1802612332?i=1802612333"
+                    "url": "https://geo.music.apple.com/us/album/ordinary/1802612332?i=1802612333"
                 },
                 "spotify": {
                     "id": "2RkZ5LkEzeHGRsmDqKwmaJ"
@@ -23971,7 +23971,7 @@
                     "video_id": "iJ-s0WYcMlM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/hydroplaning-off-the-edge-of-the-world/1839207466?i=1839207468"
+                    "url": "https://geo.music.apple.com/us/album/hydroplaning-off-the-edge-of-the-world/1839207466?i=1839207468"
                 },
                 "spotify": {
                     "id": "7dfurNiPzlhmACURpes3HP"
@@ -23997,7 +23997,7 @@
                     "video_id": "8237LGtypoA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/how-does-it-feel/1764547631?i=1764547889"
+                    "url": "https://geo.music.apple.com/us/album/how-does-it-feel/1764547631?i=1764547889"
                 },
                 "spotify": {
                     "id": "0zWMaIuePlePcnjsPmHxxF"
@@ -24023,7 +24023,7 @@
                     "video_id": "Eb7DXIfR9YI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/1-17/1795548776?i=1795548777"
+                    "url": "https://geo.music.apple.com/us/album/1-17/1795548776?i=1795548777"
                 },
                 "spotify": {
                     "id": "5cwjNspmIDLehxMTfX2NIC"
@@ -24049,7 +24049,7 @@
                     "video_id": "GvXzmHkd3Ow"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/push-me-around/1841190989?i=1841190993"
+                    "url": "https://geo.music.apple.com/us/album/push-me-around/1841190989?i=1841190993"
                 },
                 "spotify": {
                     "id": "1IO1X0d6SpveTXNOZI6T9j"
@@ -24075,7 +24075,7 @@
                     "video_id": "S7jo5Cr6WUA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/i-lied-to-you/1808534010?i=1808534192"
+                    "url": "https://geo.music.apple.com/us/album/i-lied-to-you/1808534010?i=1808534192"
                 },
                 "spotify": {
                     "id": "0XfwXFXOI7oys9rsZ2sjrt"
@@ -24101,7 +24101,7 @@
                     "video_id": "whxp5p-BBiM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/amidinin/1798701390?i=1798701393"
+                    "url": "https://geo.music.apple.com/us/album/amidinin/1798701390?i=1798701393"
                 },
                 "bandcamp": {
                     "url": "https://purplishrecords.bandcamp.com/track/amidinin"
@@ -24127,7 +24127,7 @@
                     "video_id": "aVfUwNYqrK8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/leave-me-alone/1814463235?i=1814463236"
+                    "url": "https://geo.music.apple.com/us/album/leave-me-alone/1814463235?i=1814463236"
                 },
                 "spotify": {
                     "id": "44t9rTRjK82lBbZwuePQOE"
@@ -24153,7 +24153,7 @@
                     "video_id": "wteFLJgahss"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sepsis/1842214700?i=1842214701"
+                    "url": "https://geo.music.apple.com/us/album/sepsis/1842214700?i=1842214701"
                 },
                 "spotify": {
                     "id": "3ScIZdvkqGTrhW4hZDIL00"
@@ -24179,7 +24179,7 @@
                     "video_id": "jAGRLywewfE"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/sorry/1810267152?i=1810267736"
+                    "url": "https://geo.music.apple.com/us/album/sorry/1810267152?i=1810267736"
                 },
                 "spotify": {
                     "id": "02KWhwsDjIX8ZXgBgK9kOP"
@@ -24205,7 +24205,7 @@
                     "video_id": "7k-tLs9Z8uY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/ride-feat-john-cale/1814969020?i=1814969336"
+                    "url": "https://geo.music.apple.com/us/album/ride-feat-john-cale/1814969020?i=1814969336"
                 },
                 "spotify": {
                     "id": "2MYs6hMDvXZ5U7tSCMEdIN"
@@ -24231,7 +24231,7 @@
                     "video_id": "PC0XAjEeA9w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/teethsucker-yea3x/1829472617?i=1829473538"
+                    "url": "https://geo.music.apple.com/us/album/teethsucker-yea3x/1829472617?i=1829473538"
                 },
                 "spotify": {
                     "id": "5ZgC4F4LfjZBBHZG4EOckr"
@@ -24257,7 +24257,7 @@
                     "video_id": "lzoSYOruA1w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/moscovium/1793336908?i=1793337502"
+                    "url": "https://geo.music.apple.com/us/album/moscovium/1793336908?i=1793337502"
                 },
                 "spotify": {
                     "id": "5AYa3CrtYKuGRZqsIVgPlp"
@@ -24283,7 +24283,7 @@
                     "video_id": "BolzhgBNqvI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/for-i-am-death/1830382224?i=1830382225"
+                    "url": "https://geo.music.apple.com/us/album/for-i-am-death/1830382224?i=1830382225"
                 },
                 "spotify": {
                     "id": "3K85nEutdOPbJuAJgoe2O4"
@@ -24309,7 +24309,7 @@
                     "video_id": "xS4ubqpo6KY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/people-person/1788995054?i=1788995665"
+                    "url": "https://geo.music.apple.com/us/album/people-person/1788995054?i=1788995665"
                 },
                 "spotify": {
                     "id": "11zY7E1nQFu1dOgKwA25DB"
@@ -24335,7 +24335,7 @@
                     "video_id": "CCS1ZukodrQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/emily-and-me/1805932592?i=1805932597"
+                    "url": "https://geo.music.apple.com/us/album/emily-and-me/1805932592?i=1805932597"
                 },
                 "spotify": {
                     "id": "39qhEfWsxkbhuRqs1cEfoX"
@@ -24361,7 +24361,7 @@
                     "video_id": "VrKXag66m-Y"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/time-waited/1785629697?i=1785629702"
+                    "url": "https://geo.music.apple.com/us/album/time-waited/1785629697?i=1785629702"
                 },
                 "spotify": {
                     "id": "3q5poJRpLvVxdBVpsMTBMu"
@@ -24387,7 +24387,7 @@
                     "video_id": "aY9LFNmUFos"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/dignified/1843971336?i=1843971350"
+                    "url": "https://geo.music.apple.com/us/album/dignified/1843971336?i=1843971350"
                 },
                 "spotify": {
                     "id": "0mQutndCp4cUXnrXZ9acHB"
@@ -24413,7 +24413,7 @@
                     "video_id": "wjxXWDr0uo8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/another-second-chance/1817135193?i=1817135558"
+                    "url": "https://geo.music.apple.com/us/album/another-second-chance/1817135193?i=1817135558"
                 },
                 "spotify": {
                     "id": "6aFN0owk4tiL8qXhx4IrOF"
@@ -24439,7 +24439,7 @@
                     "video_id": "k7BsTtCfjVk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/migration-patterns/1796452590?i=1796452592"
+                    "url": "https://geo.music.apple.com/us/album/migration-patterns/1796452590?i=1796452592"
                 },
                 "spotify": {
                     "id": "3CfXcxwbnrSH0AvZCMfLrO"
@@ -24465,7 +24465,7 @@
                     "video_id": "YCDAI5fcpww"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/portrait-of-my-heart/1785682530?i=1785682532"
+                    "url": "https://geo.music.apple.com/us/album/portrait-of-my-heart/1785682530?i=1785682532"
                 },
                 "spotify": {
                     "id": "2EDBjvlWHKWNyHHWMWPx1j"
@@ -24491,7 +24491,7 @@
                     "video_id": "GI18XWXHxB0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/easy-lover/1839062794?i=1839063071"
+                    "url": "https://geo.music.apple.com/us/album/easy-lover/1839062794?i=1839063071"
                 },
                 "spotify": {
                     "id": "2OBzYCYMNsD6yhBZZSs0xg"
@@ -24517,7 +24517,7 @@
                     "video_id": "Cpuw4eN4LY8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/juicy-juice-feat-marie-davidson/1801493394?i=1801493682"
+                    "url": "https://geo.music.apple.com/us/album/juicy-juice-feat-marie-davidson/1801493394?i=1801493682"
                 },
                 "spotify": {
                     "id": "1EAadJeM4oPkNIYMjG8zDH"
@@ -24543,7 +24543,7 @@
                     "video_id": "LO4luP1IkCY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/reign-feat-iggor-cavalera-jonas-karsten/1823984207?i=1823984210"
+                    "url": "https://geo.music.apple.com/us/album/reign-feat-iggor-cavalera-jonas-karsten/1823984207?i=1823984210"
                 },
                 "spotify": {
                     "id": "7EdZ03QFAprOEHNUMZ7Z8v"
@@ -24569,7 +24569,7 @@
                     "video_id": "qH6kN23Epyw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/agadez/1800290393?i=1800290401"
+                    "url": "https://geo.music.apple.com/us/album/agadez/1800290393?i=1800290401"
                 },
                 "spotify": {
                     "id": "1XciIcJvY7m3u8cq7toVlB"
@@ -24595,7 +24595,7 @@
                     "video_id": "SfCIxYOB9zU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/reel-25/1814343355?i=1814343357"
+                    "url": "https://geo.music.apple.com/us/album/reel-25/1814343355?i=1814343357"
                 },
                 "spotify": {
                     "id": "1AoJo7BkqgPJCRCQCtJ2iY"
@@ -24621,7 +24621,7 @@
                     "video_id": "lHNfZJ19h8M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/style-watching/1839321082?i=1839321639"
+                    "url": "https://geo.music.apple.com/us/album/style-watching/1839321082?i=1839321639"
                 },
                 "spotify": {
                     "id": "3k5Ecirq6FC4aWf2T7Sl7b"
@@ -24647,7 +24647,7 @@
                     "video_id": "EiarBsRPSLA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/eyez-red/1833306268?i=1833306269"
+                    "url": "https://geo.music.apple.com/us/album/eyez-red/1833306268?i=1833306269"
                 },
                 "spotify": {
                     "id": "1qbSjUjjKI0p0qRbUHaYTV"
@@ -24673,7 +24673,7 @@
                     "video_id": "Z5N87etHRso"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/this-was-a-gift/1763094429?i=1763094430"
+                    "url": "https://geo.music.apple.com/us/album/this-was-a-gift/1763094429?i=1763094430"
                 },
                 "spotify": {
                     "id": "4Bj1KgPvlZvr03fvBPJxiE"
@@ -24699,7 +24699,7 @@
                     "video_id": "9ZPzHInWs68"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mine/1853635930?i=1853635936"
+                    "url": "https://geo.music.apple.com/us/album/mine/1853635930?i=1853635936"
                 },
                 "spotify": {
                     "id": "0fKrZjwdZlwAEYi7S012mN"
@@ -24725,7 +24725,7 @@
                     "video_id": "HCwbhOGLJl4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cradle-the-pain/1783621180?i=1783621181"
+                    "url": "https://geo.music.apple.com/us/album/cradle-the-pain/1783621180?i=1783621181"
                 },
                 "spotify": {
                     "id": "04K5qfFqfxJF5yh3xaUYZS"
@@ -24751,7 +24751,7 @@
                     "video_id": "uN_qDyNhU7o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/when-did-you-get-hot/1819861154?i=1819861167"
+                    "url": "https://geo.music.apple.com/us/album/when-did-you-get-hot/1819861154?i=1819861167"
                 },
                 "spotify": {
                     "id": "0je57Uq5eTk1wrPzn9sWbl"
@@ -24777,7 +24777,7 @@
                     "video_id": "yJy9aMvUxSc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/bambis-theme/1771925266?i=1771925570"
+                    "url": "https://geo.music.apple.com/us/album/bambis-theme/1771925266?i=1771925570"
                 },
                 "spotify": {
                     "id": "4qIVsBt7IZhz0YyWufXhrO"
@@ -24803,7 +24803,7 @@
                     "video_id": "dNTwvW7Py7M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/as-alive-as-you-need-me-to-be/1826198222?i=1826198226"
+                    "url": "https://geo.music.apple.com/us/album/as-alive-as-you-need-me-to-be/1826198222?i=1826198226"
                 },
                 "spotify": {
                     "id": "06USX1htQD4LgOgX4FF0ix"
@@ -24829,7 +24829,7 @@
                     "video_id": "TeIvplrL-rQ"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/touch-myself/1808081778?i=1808082353"
+                    "url": "https://geo.music.apple.com/us/album/touch-myself/1808081778?i=1808082353"
                 },
                 "spotify": {
                     "id": "5pLF4Gf07VZTg8QqX3wDHi"
@@ -24854,7 +24854,7 @@
                     "video_id": "efOuLVI8GjY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/tinted-windows/1813894286?i=1813894288"
+                    "url": "https://geo.music.apple.com/us/album/tinted-windows/1813894286?i=1813894288"
                 },
                 "spotify": {
                     "id": "6381d3dO3SzcI1mGY17wXq"
@@ -24880,7 +24880,7 @@
                     "video_id": "NsSHyhhpOII"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/highway/1835209001?i=1835209256"
+                    "url": "https://geo.music.apple.com/us/album/highway/1835209001?i=1835209256"
                 },
                 "spotify": {
                     "id": "59pTfHqnksL9JHGbusHUiA"
@@ -24906,7 +24906,7 @@
                     "video_id": "PGLikycTXgg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/digital-emotional/1798515627?i=1798515629"
+                    "url": "https://geo.music.apple.com/us/album/digital-emotional/1798515627?i=1798515629"
                 },
                 "spotify": {
                     "id": "04tKVEySP4qGEiXQ5EkXMI"
@@ -24932,7 +24932,7 @@
                     "video_id": "bojWyLj3IPs"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/lose-it-again/1831541288?i=1831541438"
+                    "url": "https://geo.music.apple.com/us/album/lose-it-again/1831541288?i=1831541438"
                 },
                 "spotify": {
                     "id": "7dLMXmaRAEpXhuWLTv0iqL"
@@ -24958,7 +24958,7 @@
                     "video_id": "ITOSo9FVGv0"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/affirmations/1800184332?i=1800184333"
+                    "url": "https://geo.music.apple.com/us/album/affirmations/1800184332?i=1800184333"
                 },
                 "spotify": {
                     "id": "7HN4SqrMZ30m4RWYm29gJv"
@@ -24984,7 +24984,7 @@
                     "video_id": "OCSp6X7u5gw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/horseglue/1841252410?i=1841252411"
+                    "url": "https://geo.music.apple.com/us/album/horseglue/1841252410?i=1841252411"
                 },
                 "spotify": {
                     "id": "4OUXSMtGYH0Vacg7W6zCwS"
@@ -25010,7 +25010,7 @@
                     "video_id": "l4Cd3intdYk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/devotion/1831393582?i=1831393595"
+                    "url": "https://geo.music.apple.com/us/album/devotion/1831393582?i=1831393595"
                 },
                 "spotify": {
                     "id": "30JRrogttGqqZj2wTxCHe8"
@@ -25035,7 +25035,7 @@
                     "video_id": "bQsm8dkXJwc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/triumph/1844746437?i=1844746438"
+                    "url": "https://geo.music.apple.com/us/album/triumph/1844746437?i=1844746438"
                 },
                 "spotify": {
                     "id": "4uwdzhJ3WIStAyGpzLyZlb"
@@ -25061,7 +25061,7 @@
                     "video_id": "MGSXjxPtSPg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/you/1803726233?i=1803726239"
+                    "url": "https://geo.music.apple.com/us/album/you/1803726233?i=1803726239"
                 },
                 "spotify": {
                     "id": "13vpSZ4nzZFBQNzmlR7HP2"
@@ -25087,7 +25087,7 @@
                     "video_id": "rp0mim23lYo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/anywhere-2023-2024/1808353640?i=1808353643"
+                    "url": "https://geo.music.apple.com/us/album/anywhere-2023-2024/1808353640?i=1808353643"
                 },
                 "spotify": {
                     "id": "49CMjBtwoyRXae8Mth2LF2"
@@ -25116,7 +25116,7 @@
                     "video_id": "eN2RV6HHVkU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/skeletree/1830007934?i=1830007938"
+                    "url": "https://geo.music.apple.com/us/album/skeletree/1830007934?i=1830007938"
                 },
                 "spotify": {
                     "id": "3rGu21P8XTUi1PhqvKCTe1"
@@ -25142,7 +25142,7 @@
                     "video_id": "cAANqvXEKAw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/building-650/1774397756?i=1774397759"
+                    "url": "https://geo.music.apple.com/us/album/building-650/1774397756?i=1774397759"
                 },
                 "spotify": {
                     "id": "6JrtUQ97SQqVoMW5bWFd7I"
@@ -25168,7 +25168,7 @@
                     "video_id": "UxN0GimyOtU"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/mirror/1765347263?i=1765347633"
+                    "url": "https://geo.music.apple.com/us/album/mirror/1765347263?i=1765347633"
                 },
                 "spotify": {
                     "id": "4RUyxhyD0U1nJEYGex9k98"
@@ -25194,7 +25194,7 @@
                     "video_id": "N_D579R2M3A"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/boys-these-days/1790499083?i=1790499090"
+                    "url": "https://geo.music.apple.com/us/album/boys-these-days/1790499083?i=1790499090"
                 },
                 "spotify": {
                     "id": "5dhCaTX2DKPcUgY5VhlC4R"
@@ -25220,7 +25220,7 @@
                     "video_id": "BXfO4pDbjQk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-pilot/1785683592?i=1785683593"
+                    "url": "https://geo.music.apple.com/us/album/the-pilot/1785683592?i=1785683593"
                 },
                 "spotify": {
                     "id": "3lf4HoJOhYrSKts3ohKUmT"
@@ -25246,7 +25246,7 @@
                     "video_id": "c74FVIKz-ug"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/run-it-up/1830591137?i=1830591217"
+                    "url": "https://geo.music.apple.com/us/album/run-it-up/1830591137?i=1830591217"
                 },
                 "spotify": {
                     "id": "73EKQrgYNVwOaKdwh5a1PV"
@@ -25272,7 +25272,7 @@
                     "video_id": "fnSbTp5WgJc"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/doubt/1806107071?i=1806107084"
+                    "url": "https://geo.music.apple.com/us/album/doubt/1806107071?i=1806107084"
                 },
                 "spotify": {
                     "id": "2dexrJhfT8hQEvH7uqNpRf"
@@ -25297,7 +25297,7 @@
                     "video_id": "SIGDCt-fWhw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/me-and-aquil-stealing-stuff-from-work/1817665332?i=1817665548"
+                    "url": "https://geo.music.apple.com/us/album/me-and-aquil-stealing-stuff-from-work/1817665332?i=1817665548"
                 },
                 "spotify": {
                     "id": "1iuQNv9Jbn0zYlYeJm85f1"
@@ -25322,7 +25322,7 @@
                     "video_id": "Yl46W3bJo9w"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/m-r/1804151130?i=1804151599"
+                    "url": "https://geo.music.apple.com/us/album/m-r/1804151130?i=1804151599"
                 },
                 "spotify": {
                     "id": "55abDFBW5pPb1HjYvIapEa"
@@ -25394,7 +25394,7 @@
                     "video_id": "9wIg39LeWfw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/5/1794764757?i=1794764762"
+                    "url": "https://geo.music.apple.com/us/album/5/1794764757?i=1794764762"
                 },
                 "spotify": {
                     "id": "7CK4bpTIiYWYp478jgSlgp"
@@ -25420,7 +25420,7 @@
                     "video_id": "Mu9b788t0MM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/magnet/1816490472?i=1816490473"
+                    "url": "https://geo.music.apple.com/us/album/magnet/1816490472?i=1816490473"
                 },
                 "spotify": {
                     "id": "24uUPnVhCzhpFYlqZDrhN3"
@@ -25446,7 +25446,7 @@
                     "video_id": "KCeYIlS7CF8"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/luke-leanna/1785690857?i=1785690999"
+                    "url": "https://geo.music.apple.com/us/album/luke-leanna/1785690857?i=1785690999"
                 },
                 "spotify": {
                     "id": "4MtXbKTXoT5t8GTwVCYzvY"
@@ -25472,7 +25472,7 @@
                     "video_id": "e4m27fTh51M"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/big-pink-bubble/1794412465?i=1794412469"
+                    "url": "https://geo.music.apple.com/us/album/big-pink-bubble/1794412465?i=1794412469"
                 },
                 "spotify": {
                     "id": "4jp9Es2eqWIZZyrEIir7zu"
@@ -25498,7 +25498,7 @@
                     "video_id": "pKXZ4j13TOg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/knockin-heart/1781187698?i=1781188377"
+                    "url": "https://geo.music.apple.com/us/album/knockin-heart/1781187698?i=1781188377"
                 },
                 "spotify": {
                     "id": "3IFk55tJwqBrdhgsLvrVvn"
@@ -25524,7 +25524,7 @@
                     "video_id": "mfTK4IJMEhI"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/see-u-dance-feat-rebecca-black/1824543248?i=1824543374"
+                    "url": "https://geo.music.apple.com/us/album/see-u-dance-feat-rebecca-black/1824543248?i=1824543374"
                 },
                 "spotify": {
                     "id": "0mxBL9v4xZM0q4GAhJWbHB"
@@ -25550,7 +25550,7 @@
                     "video_id": "yJ5W2_wiv7o"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/not-hell-not-heaven/1785686511?i=1785686525"
+                    "url": "https://geo.music.apple.com/us/album/not-hell-not-heaven/1785686511?i=1785686525"
                 },
                 "spotify": {
                     "id": "3Dv3zgW4OHauERx9RIZUXL"
@@ -25576,7 +25576,7 @@
                     "video_id": "moZCN3FmwZY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/cold-heart/1807973507?i=1807973840"
+                    "url": "https://geo.music.apple.com/us/album/cold-heart/1807973507?i=1807973840"
                 },
                 "spotify": {
                     "id": "5WRdonm8caliL2JA6fT2fL"
@@ -25602,7 +25602,7 @@
                     "video_id": "TCqoXmBu5gg"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/saoirse/1811588644?i=1811588652"
+                    "url": "https://geo.music.apple.com/us/album/saoirse/1811588644?i=1811588652"
                 },
                 "spotify": {
                     "id": "3g0xd9m1MxKRiIC2Xw4998"
@@ -25628,7 +25628,7 @@
                     "video_id": "cHgBkMdfshw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/wild-long-lie/1845916617?i=1845916626"
+                    "url": "https://geo.music.apple.com/us/album/wild-long-lie/1845916617?i=1845916626"
                 },
                 "spotify": {
                     "id": "5lQS3Q71OZWEA2tt7TcWai"
@@ -25654,7 +25654,7 @@
                     "video_id": "JqvoWvbnRDo"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/elizabeth-taylor/1838810949?i=1838810952"
+                    "url": "https://geo.music.apple.com/us/album/elizabeth-taylor/1838810949?i=1838810952"
                 },
                 "spotify": {
                     "id": "1jgTiNob5cVyXeJ3WgX5bL"
@@ -25680,7 +25680,7 @@
                     "video_id": "Xh_A_AIDOs4"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/angel/1786672343?i=1786672367"
+                    "url": "https://geo.music.apple.com/us/album/angel/1786672343?i=1786672367"
                 },
                 "spotify": {
                     "id": "2RTlcEKqNPoJmLExbKMmqz"
@@ -25706,7 +25706,7 @@
                     "video_id": "uAyYglWhnjM"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/second-life/1820154664?i=1820154672"
+                    "url": "https://geo.music.apple.com/us/album/second-life/1820154664?i=1820154672"
                 },
                 "spotify": {
                     "id": "6uRp0phyIJbLCYcefThba2"
@@ -25732,7 +25732,7 @@
                     "video_id": "dXqS5q3EsNw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/divinize/1848167516?i=1848167523"
+                    "url": "https://geo.music.apple.com/us/album/divinize/1848167516?i=1848167523"
                 },
                 "spotify": {
                     "id": "2JH26hQtnqWUNnQET8o2N1"

--- a/samples/sample_data.json
+++ b/samples/sample_data.json
@@ -256,37 +256,201 @@
     },
     "songs": [
         {
-            "id": "USSM12504030",
-            "artist": "ROSAL\u00cdA",
-            "name": "Reliquia",
+            "id": "QMFMF2447070",
+            "artist": "Bad Bunny",
+            "name": "DtMF",
             "sources": [
                 {
-                    "name": "Paste",
-                    "rank": 7,
-                    "quote": "opening cascade of vibrant strings ... provides an opening for ROSAL\u00cdA to wax poetic on the trappings of fame"
+                    "name": "Vulture",
+                    "rank": 1,
+                    "quote": "missing someone doesn't have to kill the party"
                 },
                 {
-                    "name": "NME",
-                    "rank": 7,
-                    "quote": "its gorgeous opening string arrangement melting into gently thumping electronic production"
+                    "name": "Billboard Staff",
+                    "rank": 15,
+                    "quote": "as spirit-rousing and soul-lifting a singalong as we got in 2025 pop"
+                },
+                {
+                    "name": "Complex",
+                    "rank": 25,
+                    "quote": "Driven by a pulsating Bomba rhythm ... it feels like a full-on studio party. Yet beneath all the festive energy, there's a subtle melancholy."
+                },
+                {
+                    "name": "Quietus",
+                    "rank": 34
+                },
+                {
+                    "name": "FADER",
+                    "rank": 35,
+                    "quote": "the magic of Bad Bunny's lyrics about lamenting missed opportunities ... is the multiple interpretations"
                 },
                 {
                     "name": "Slant",
-                    "rank": 14,
-                    "quote": "projects a heavenly tranquility as she lists the sacrifices she's made for art and love"
+                    "rank": 45,
+                    "quote": "a subtle, wistful combination of plena and reggaeton ... like a bar room singalong"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 65,
+                    "quote": "the slow burn of those quiet synths, which gallop towards a dembow and culminates in the best singalong chorus in pop music since \"Mr. Brightside\""
+                }
+            ],
+            "list_count": 7,
+            "media": {
+                "youtube": {
+                    "music_id": "TiebZllW8As",
+                    "video_id": "v9T_MGfzq7I"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/dtmf/1787022393?i=1787023936"
+                },
+                "spotify": {
+                    "id": "3sK8wGT43QFpWrvNQsrQya"
+                }
+            },
+            "genres": "Reggaeton"
+        },
+        {
+            "id": "US2U62539801",
+            "artist": "feeble little horse",
+            "name": "This Is Real",
+            "sources": [
+                {
+                    "name": "AP",
+                    "uses_shadow_rank": true,
+                    "quote": "pushes the envelope further, working in computerized, hyperpop-esque electronics ... one of their heaviest tracks to date"
+                },
+                {
+                    "name": "Stereogum",
+                    "rank": 45,
+                    "quote": "glitchy jangle riffs, overlapping twee-folk refrains\u2026 and the heaviest breakdown this year outside of metal"
+                },
+                {
+                    "name": "Quietus",
+                    "rank": 47
+                },
+                {
+                    "name": "Rolling Stone",
+                    "rank": 82,
+                    "quote": "collide bedroom pop, noise pop, and hyper pop ... turns into bubbly electro cuteness, then runs into a wall of power-drone grind, then becomes a Nineties-style grunge-punk tantrum"
+                }
+            ],
+            "list_count": 4,
+            "media": {
+                "youtube": {
+                    "music_id": "4tT4thtTees",
+                    "video_id": "ZZ5ARgm--Ok"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/this-is-real/1796181543?i=1796181548"
+                },
+                "spotify": {
+                    "id": "4LYXtoiuM9xEmxklVvQnLl"
+                },
+                "bandcamp": {
+                    "url": "https://feeblelittlehorse.bandcamp.com/track/this-is-real"
+                }
+            },
+            "genres": "Shoegaze"
+        },
+        {
+            "id": "NLA322500073",
+            "artist": "Turnstile",
+            "name": "BIRDS",
+            "sources": [
+                {
+                    "name": "Crack",
+                    "rank": 2,
+                    "quote": "there is simply no other band doing it like Turnstile"
+                },
+                {
+                    "name": "Consequence",
+                    "rank": 4,
+                    "quote": "walking the fine line between chaos and control with an energy that's unrelenting, feral, and unmistakably their own"
+                },
+                {
+                    "name": "Rough Trade",
+                    "uses_shadow_rank": true,
+                    "quote": "The band continue to create anthemic, community moments with this standout track"
                 }
             ],
             "list_count": 3,
             "media": {
                 "youtube": {
-                    "music_id": "QI2kMNHKC2M",
-                    "video_id": "xPaSuWrBAQI"
+                    "music_id": "bptXEszZMuk",
+                    "video_id": "bptXEszZMuk"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/reliquia/1848167516?i=1848167522"
+                    "url": "https://geo.music.apple.com/us/album/birds/1826568800?i=1826569145"
                 },
                 "spotify": {
-                    "id": "4ORvXsPK9AJmDzm36BYcdy"
+                    "id": "0k9JIBszlCqCa4SpXI353F"
+                }
+            },
+            "genres": "Hardcore Punk"
+        },
+        {
+            "id": "USSM12504034",
+            "artist": "ROSAL\u00cdA, Bj\u00f6rk, & Yves Tumor",
+            "name": "Berghain",
+            "sources": [
+                {
+                    "name": "Guardian",
+                    "rank": 1,
+                    "quote": "The towering, gothic Berghain subsumes the listener ... being overwhelmed by a lover's fear, anger, love and blood"
+                },
+                {
+                    "name": "Crack",
+                    "rank": 1,
+                    "quote": "the sheer power of its confident maximalism"
+                },
+                {
+                    "name": "Quietus",
+                    "rank": 1,
+                    "quote": "an all-cylinders blast of booming orchestral baroque and operatic vocals ... redraws the boundaries of what's possible in modern pop music"
+                },
+                {
+                    "name": "FADER",
+                    "rank": 6,
+                    "quote": "belts in anguished German, wielding her airy falsetto with gusto as she unleashes the obsessive distress that dominates her inner dialogue"
+                },
+                {
+                    "name": "Rolling Stone",
+                    "rank": 14,
+                    "quote": "all urgent, frenzied strings and soaring operatic vocals, signaling a dark grandeur few were expecting"
+                },
+                {
+                    "name": "ELLE",
+                    "uses_shadow_rank": true,
+                    "quote": "a beautifully frenzied fever dream ... sensual, gothic, poignant, and slightly unhinged"
+                },
+                {
+                    "name": "Variety",
+                    "uses_shadow_rank": true,
+                    "quote": "a composition that includes a symphony orchestra and choir blasting so loudly you'd think they were soundtracking an especially beautiful \"Omen\" reboot"
+                },
+                {
+                    "name": "Rough Trade",
+                    "uses_shadow_rank": true,
+                    "quote": "Unlike anything else I have heard this year"
+                },
+                {
+                    "name": "Billboard Staff",
+                    "rank": 34,
+                    "quote": "scales her ambition to nothing less than operatic majesty, achieving this aim with a tour de force that feels vastly bigger than its slim three minutes"
+                }
+            ],
+            "list_count": 9,
+            "media": {
+                "youtube": {
+                    "music_id": "2dKMNZIK45M",
+                    "video_id": "htQBS2Ikz6c"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/berghain/1848167516?i=1848167528"
+                },
+                "spotify": {
+                    "id": "2T8yuUKl1nhmtaIocqWo4i"
                 }
             },
             "genres": "Latin"
@@ -329,7 +493,7 @@
                     "video_id": "6vLZjyKuWEY"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/special/1818861416?i=1818861424"
+                    "url": "https://geo.music.apple.com/us/album/special/1818861416?i=1818861424"
                 },
                 "spotify": {
                     "id": "7HWDQfrQvnAXp5Xk29xqh7"
@@ -338,435 +502,199 @@
             "genres": "Lo-Fi Indie"
         },
         {
-            "id": "USUG12506170",
-            "artist": "Chappell Roan",
-            "name": "The Subway",
+            "id": "USUG12506174",
+            "artist": "Justin Bieber",
+            "name": "YUKON",
             "sources": [
                 {
-                    "name": "EW",
-                    "rank": 2,
-                    "quote": "the vivid imagery in their dream-pop stunner \"The Subway\" is a big reason why it's so relatably, palpably devastating"
-                },
-                {
-                    "name": "USA Today",
-                    "rank": 2,
-                    "quote": "a throwback to the '90s jangle-pop of The Cranberries and The Sundays ... Roan's voice aches with heartbreak"
+                    "name": "Complex",
+                    "rank": 1,
+                    "quote": "\"Yukon,\" an intimate and hypnotic acoustic showcase ... the best song to drop this year, but perhaps the best in his catalogue"
                 },
                 {
                     "name": "LA Times",
-                    "rank": 3,
-                    "quote": "The vocal performance of the year."
-                },
-                {
-                    "name": "Guardian",
-                    "rank": 3,
-                    "quote": "a lovelorn Celtic pop epic in thrall to the Cranberries ... reprising those torchbearers' snarling, choral rage"
-                },
-                {
-                    "name": "Independent",
-                    "uses_shadow_rank": true,
-                    "quote": "\"The Subway\" is an open-hearted, grandiose slice of big-city yearning ... It sounds a little like something the late Dolores O'Riordan could have made, which only adds to its sublime melancholy."
-                },
-                {
-                    "name": "AP",
-                    "uses_shadow_rank": true,
-                    "quote": "slow-burn dream-pop with Roan demonstrating her chameleonic properties by channeling both the Cranberries' Dolores O'Riordan and Alanis Morissette's yodel"
-                },
-                {
-                    "name": "Billboard Staff",
-                    "rank": 8,
-                    "quote": "utterly resplendent"
-                },
-                {
-                    "name": "Rolling Stone",
-                    "rank": 10,
-                    "quote": "this delicious heartbreaker ... the most emotionally devastating song about standing on a subway platform"
-                },
-                {
-                    "name": "Stereogum",
-                    "rank": 11,
-                    "quote": "a lovely, anthemic coda ... It's melancholy but somehow at peace, and totally sublime"
+                    "rank": 4,
+                    "quote": "Bieber will never escape the power of his high-pitched voice"
                 },
                 {
                     "name": "Slant",
-                    "rank": 13,
-                    "quote": "A midtempo dream-pop ballad\u2014replete with crisp, teary-eyed guitars\u2014that finds Chappell Roan achingly pining for the one that got away"
+                    "rank": 16,
+                    "quote": "sway gently in the breeze, set only to sparingly strummed guitar"
                 },
                 {
-                    "name": "Crack",
-                    "rank": 17,
-                    "quote": "a moment of pure cathartic release"
+                    "name": "Billboard Staff",
+                    "rank": 18,
+                    "quote": "a slow-burning soul groove ... proves he's no longer the innocent dreamer, becoming an R&B radio hit in the process"
                 },
                 {
-                    "name": "Consequence",
-                    "rank": 24,
-                    "quote": "offers a remarkable glimmer of Roan's cross-genre potential"
-                },
-                {
-                    "name": "ELLE",
-                    "uses_shadow_rank": true,
-                    "quote": "a dreamy '90s pop-rock feel, reminiscent of The Cranberries"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 31,
-                    "quote": "She's haunted by signs of her ex ... the flash of green hair and a beauty mark on a stranger that makes her heart stop"
-                },
-                {
-                    "name": "Rough Trade",
-                    "uses_shadow_rank": true,
-                    "quote": "paints such a devastatingly clear picture of lost love"
-                },
-                {
-                    "name": "NME",
-                    "rank": 35,
-                    "quote": "[she] lets completely loose ... the passionate, gut-wrenching two-minute outro"
+                    "name": "FADER",
+                    "rank": 44,
+                    "quote": "The original track is slinky, sly and easy on the ears ... Bieber's agile falsetto is still manna from pop heaven"
                 }
             ],
-            "list_count": 16,
+            "list_count": 5,
             "media": {
                 "youtube": {
-                    "music_id": "Qam5A9lG-wc",
-                    "video_id": "woLfAvD5iXI"
+                    "music_id": "-R-rqf-w2MY",
+                    "video_id": "fXivMSJm_kA"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/the-subway/1828261054?i=1828261475"
+                    "url": "https://geo.music.apple.com/us/album/yukon/1839605744?i=1839605914"
                 },
                 "spotify": {
-                    "id": "2SsY5k7UWFqgye3PUMG3Oq"
+                    "id": "29iva9idM6rFCPUlu7Rhxl"
                 }
             },
             "genres": "Pop"
         },
         {
-            "id": "USJ5G2542802",
-            "artist": "Wednesday",
-            "name": "Townies",
+            "id": "QM4TW2517490",
+            "artist": "Little Simz, Obongjayar, & Moonchild Sanelly",
+            "name": "Flood",
             "sources": [
-                {
-                    "name": "Stereogum",
-                    "rank": 1,
-                    "quote": "a master of writing grimy, evocative scenes of troubled youth that are daringly specific"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 7
-                },
                 {
                     "name": "Consequence",
-                    "rank": 9,
-                    "quote": "the ultimate Wednesday song ... offers up one of the best examples of their countrygaze stylings"
+                    "rank": 18,
+                    "quote": "The UK rapper addresses betrayal with a haunting cadence and thunderous drums, taking no prisoners as she offers up hard-earned clarity and advice."
                 },
                 {
-                    "name": "NPR Top 25",
-                    "uses_shadow_rank": true,
-                    "quote": "catchy, country-influenced storytelling and the rock-star ability to stretch the word \"died\" into nine syllables"
-                },
-                {
-                    "name": "Paste",
-                    "rank": 21,
-                    "quote": "A mature and masterful missive from one of our greatest working songwriters"
-                },
-                {
-                    "name": "NME",
-                    "rank": 42,
-                    "quote": "excavating the pains of the past helps with closure"
-                }
-            ],
-            "list_count": 6,
-            "media": {
-                "youtube": {
-                    "music_id": "mHEiyObNciA",
-                    "video_id": "E8cKoQqdtwA"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/townies/1807870796?i=1807870800"
-                },
-                "spotify": {
-                    "id": "2deA4WXDrTa7jAZuaIAeqo"
-                },
-                "bandcamp": {
-                    "url": "https://wednesdayband.bandcamp.com/track/townies"
-                }
-            },
-            "genres": "Alt Country"
-        },
-        {
-            "id": "QZVEM2532603",
-            "artist": "zayALLCAPS",
-            "name": "MTV's Pimp My Ride",
-            "sources": [
-                {
-                    "name": "FADER",
-                    "rank": 28,
-                    "quote": "blurs the line between meet-cute, seduction, and homage to the titular 2000s reality TV staple"
-                },
-                {
-                    "name": "Consequence",
-                    "rank": 37,
-                    "quote": "zayALLCAPS knows how to make even the most throwback sounds feel current and unique"
-                },
-                {
-                    "name": "Paste",
-                    "rank": 47,
-                    "quote": "proves that nostalgia isn't the artistically bankrupt strategy many make it out to be"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 50,
-                    "quote": "an R&B jam with the same zaniness that made the show so popular"
-                }
-            ],
-            "list_count": 4,
-            "media": {
-                "youtube": {
-                    "music_id": "S4OzEth_euE",
-                    "video_id": "S4OzEth_euE"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/mtvs-pimp-my-ride/1802142712?i=1802142713"
-                },
-                "spotify": {
-                    "id": "6sRu3Bf5hxIRCQ8XGfYv1c"
-                }
-            },
-            "genres": "R&B/Soul"
-        },
-        {
-            "id": "US2U62539801",
-            "artist": "feeble little horse",
-            "name": "This Is Real",
-            "sources": [
-                {
-                    "name": "AP",
-                    "uses_shadow_rank": true,
-                    "quote": "pushes the envelope further, working in computerized, hyperpop-esque electronics ... one of their heaviest tracks to date"
-                },
-                {
-                    "name": "Stereogum",
-                    "rank": 45,
-                    "quote": "glitchy jangle riffs, overlapping twee-folk refrains\u2026 and the heaviest breakdown this year outside of metal"
-                },
-                {
-                    "name": "Quietus",
-                    "rank": 47
-                },
-                {
-                    "name": "Rolling Stone",
-                    "rank": 82,
-                    "quote": "collide bedroom pop, noise pop, and hyper pop ... turns into bubbly electro cuteness, then runs into a wall of power-drone grind, then becomes a Nineties-style grunge-punk tantrum"
-                }
-            ],
-            "list_count": 4,
-            "media": {
-                "youtube": {
-                    "music_id": "4tT4thtTees",
-                    "video_id": "ZZ5ARgm--Ok"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/this-is-real/1796181543?i=1796181548"
-                },
-                "spotify": {
-                    "id": "4LYXtoiuM9xEmxklVvQnLl"
-                },
-                "bandcamp": {
-                    "url": "https://feeblelittlehorse.bandcamp.com/track/this-is-real"
-                }
-            },
-            "genres": "Shoegaze"
-        },
-        {
-            "id": "QMFMF2447057",
-            "artist": "Bad Bunny",
-            "name": "BAILE INoLVIDABLE",
-            "sources": [
-                {
-                    "name": "LA Times",
-                    "rank": 1,
-                    "quote": "a six-minute ode to the island's roots and influence on the genre ... salsa has become cool once again"
-                },
-                {
-                    "name": "Rolling Stone",
-                    "rank": 4,
-                    "quote": "the album's most poignant facet is his take on salsa"
-                },
-                {
-                    "name": "EW",
-                    "rank": 4,
-                    "quote": "six minutes of pure, unbridled joy, a glorious and exultant tribute to salsa and the power of dance"
-                },
-                {
-                    "name": "Complex",
-                    "rank": 6,
-                    "quote": "a salsa track ... it features a twist ... lively salsa rhythms, layered with twinkling pianos, congas, timbales, and a brassy trumpet melody that could make anyone dance"
-                },
-                {
-                    "name": "NME",
-                    "rank": 10,
-                    "quote": "'Baile Inolvidable' is one of his most magnificent torch songs"
-                },
-                {
-                    "name": "NPR Top 25",
-                    "uses_shadow_rank": true,
-                    "quote": "The song comes alive in a complex expression of communal pain"
+                    "name": "Guardian",
+                    "rank": 20,
+                    "quote": "she lays out her six-point plan for greatness with koans of wisdom such as: \"Never eat with the hyenas / 'Cause they will look at you as bones.\""
                 },
                 {
                     "name": "ELLE",
                     "uses_shadow_rank": true,
-                    "quote": "melancholy, but glows with warm instrumentation and harmonies"
-                },
-                {
-                    "name": "Slant",
-                    "rank": 27,
-                    "quote": "a spine-chilling collision of old and new ... turning the dance floor into a metaphor for life itself: as a party that must end"
-                }
-            ],
-            "list_count": 8,
-            "media": {
-                "youtube": {
-                    "music_id": "JseJETvMtHY",
-                    "video_id": "a1Femq4NPxs"
-                },
-                "apple": {
-                    "url": "https://music.apple.com/us/album/baile-inolvidable/1787022393?i=1787022842"
-                },
-                "spotify": {
-                    "id": "2lTm559tuIvatlT1u0JYG2"
-                }
-            },
-            "genres": "Reggaeton"
-        },
-        {
-            "id": "GBBKS2500077",
-            "artist": "Jim Legxacy",
-            "name": "stick",
-            "sources": [
-                {
-                    "name": "Vulture",
-                    "rank": 4,
-                    "quote": "surveys tough times sweetly"
-                },
-                {
-                    "name": "FADER",
-                    "rank": 8,
-                    "quote": "inexplicably moving and seriously addictive"
-                },
-                {
-                    "name": "NPR Top 25",
-                    "uses_shadow_rank": true,
-                    "quote": "the ascendant U.K. rapper is an aerial dancer here, whirling between half-sung catch phrases on a ribbon of hummed chords"
+                    "quote": "a master class in storytelling, showing a profound confidence from the rapper"
                 }
             ],
             "list_count": 3,
             "media": {
                 "youtube": {
-                    "music_id": "YrVJE_6Hg6c",
-                    "video_id": "qfDIhj8UIfc"
-                },
-                "spotify": {
-                    "id": "03zypUrD0e5vrFcmc80NJm"
-                }
-            }
-        },
-        {
-            "id": "GBBKS2500311",
-            "artist": "Jim Legxacy",
-            "name": "'06 wayne rooney",
-            "sources": [
-                {
-                    "name": "GvsB",
-                    "rank": 9
-                },
-                {
-                    "name": "Quietus",
-                    "rank": 19,
-                    "quote": "a painful and refreshingly open insight into the effects of the chaos that life throws at us"
-                },
-                {
-                    "name": "Stereogum",
-                    "rank": 30,
-                    "quote": "Converting inner-city turmoil into pillowy singalong hooks is something that comes natural for Jim Legxacy"
-                },
-                {
-                    "name": "Rough Trade",
-                    "uses_shadow_rank": true,
-                    "quote": "the perfect example of Jim's power in evoking an era, producing nostalgia and reflecting on real life shit"
-                },
-                {
-                    "name": "Paste",
-                    "rank": 59,
-                    "quote": "[A] poignant reminder that \"making it\" isn't always a salve for old wounds"
-                },
-                {
-                    "name": "Consequence",
-                    "rank": 191,
-                    "quote": "Channeling the spirit of mid-aughts landfill indie and a myriad of bangers from FIFA soundtracks"
-                }
-            ],
-            "list_count": 6,
-            "media": {
-                "youtube": {
-                    "music_id": "Yq8EXOJbsCE",
-                    "video_id": "RhjZgIk9oCs"
-                },
-                "spotify": {
-                    "id": "7p6LdEcYnSbw68yJDbUjxD"
-                }
-            }
-        },
-        {
-            "id": "GBLZC2400049",
-            "artist": "aya",
-            "name": "off to the ESSO",
-            "sources": [
-                {
-                    "name": "Quietus",
-                    "rank": 2,
-                    "quote": "nerve-jangling sound design, delirium tremens percussion skitter ... actually combine to produce one of the most life-affirming bangers of recent years"
-                },
-                {
-                    "name": "Stereogum",
-                    "rank": 13,
-                    "quote": "nauseating dubstep-meets-gabber ... [with] timbres [that] squelch and burst"
-                },
-                {
-                    "name": "Guardian",
-                    "rank": 14,
-                    "quote": "conjures the skull-clattering experience of being too drunk on public transport at an indeterminate morning hour"
-                },
-                {
-                    "name": "Pitchfork",
-                    "rank": 17,
-                    "quote": "a terrifying, upsetting portrait of drug addiction"
-                },
-                {
-                    "name": "Dazed",
-                    "rank": 17,
-                    "quote": "bundles all of this up in a frantic three-and-a-half minutes, beginning with a thumping bass ... culminating with a ruckus of aggressive synths"
-                },
-                {
-                    "name": "Paste",
-                    "rank": 45,
-                    "quote": "You can feel every buzz, screech, and smack in your bones, taking over your whole being like a persistent parasite"
-                }
-            ],
-            "list_count": 6,
-            "media": {
-                "youtube": {
-                    "music_id": "yBMSzoovWbw",
-                    "video_id": "-vgDl8Asle0"
+                    "music_id": "FEORaPiNF6g",
+                    "video_id": "GvrNPiz7rHw"
                 },
                 "apple": {
-                    "url": "https://music.apple.com/us/album/off-to-the-esso/1791674346?i=1791674348"
+                    "url": "https://geo.music.apple.com/us/album/flood-feat-obongjayar-moonchild-sanelly/1794880972?i=1794880975"
                 },
                 "spotify": {
-                    "id": "4BsGxMMDdcWQzrUTGXqlAE"
-                },
-                "bandcamp": {
-                    "url": "https://aya-yco.bandcamp.com/track/off-to-the-esso"
+                    "id": "3m9g8ua3M51JvqmS8rh6bS"
                 }
             },
-            "genres": "Experimental"
+            "genres": "Hip-Hop"
+        },
+        {
+            "id": "USSM12501572",
+            "artist": "Addison Rae",
+            "name": "Fame is a Gun",
+            "sources": [
+                {
+                    "name": "LA Times",
+                    "rank": 7,
+                    "quote": "pop-star manifesto"
+                },
+                {
+                    "name": "Slant",
+                    "rank": 7,
+                    "quote": "Like fame itself, the song is as enticing as it is foreboding"
+                },
+                {
+                    "name": "Billboard Staff",
+                    "rank": 22,
+                    "quote": "a feathery electro-pop banger that would make Britney Spears smile"
+                },
+                {
+                    "name": "Paste",
+                    "rank": 24,
+                    "quote": "leans coyly into a Britneyesque whine that seems to encapsulate her contemporary climb to \"legitimate\" artistry"
+                },
+                {
+                    "name": "Variety",
+                    "uses_shadow_rank": true,
+                    "quote": "a tightly written and sharply produced collection of pop songs that confronts the nature of celebrity while unabashedly embracing it"
+                }
+            ],
+            "list_count": 5,
+            "media": {
+                "youtube": {
+                    "music_id": "APvEk-IEGJ4",
+                    "video_id": "TkwZ2uQu2hE"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/fame-is-a-gun/1809015416?i=1809015879"
+                },
+                "spotify": {
+                    "id": "7B3BwNecBhKvNwSMOOl7Gk"
+                }
+            },
+            "genres": "Pop"
+        },
+        {
+            "id": "USUM72501138",
+            "artist": "Skrilla",
+            "name": "Doot Doot (6 7)",
+            "sources": [
+                {
+                    "name": "FADER",
+                    "rank": 6.7,
+                    "quote": "Skrilla managed to do the impossible: create one of the last instances of monoculture"
+                },
+                {
+                    "name": "Complex",
+                    "rank": 13,
+                    "quote": "\"Doot Doot\" is unapologetically Skrilla: violent, with that dramatic Philly drill sound"
+                },
+                {
+                    "name": "NPR Top 125",
+                    "uses_shadow_rank": true,
+                    "quote": "the song is undeniable ... drill dressed up in a Jason Voorhees mask"
+                }
+            ],
+            "list_count": 3,
+            "media": {
+                "youtube": {
+                    "music_id": "2fWeH9HwmCo",
+                    "video_id": "XnygT6ANLzQ"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/doot-doot-6-7-bonus-track/1798833506?i=1798833782"
+                },
+                "spotify": {
+                    "id": "18DEvCPCmzVpo2en9DeylA"
+                }
+            },
+            "genres": "Hip-Hop/Rap"
+        },
+        {
+            "id": "USUG12506436",
+            "artist": "Taylor Swift",
+            "name": "The Fate of Ophelia",
+            "sources": [
+                {
+                    "name": "Rolling Stone",
+                    "rank": 8,
+                    "quote": "[She] goes back in time to rescue a tragic young heroine and give her a new story"
+                },
+                {
+                    "name": "Billboard Staff",
+                    "rank": 14,
+                    "quote": "an eyes-wide-open heroine who worries that she's doomed to the tragic fate of Hamlet's wife"
+                }
+            ],
+            "list_count": 2,
+            "media": {
+                "youtube": {
+                    "music_id": "7nVctvQVz0U",
+                    "video_id": "ko70cExuzZM"
+                },
+                "apple": {
+                    "url": "https://geo.music.apple.com/us/album/the-fate-of-ophelia/1833328839?i=1833328840"
+                },
+                "spotify": {
+                    "id": "53iuhJlwXhSER5J2IYYv1W"
+                }
+            },
+            "genres": "Pop"
         }
     ]
 }


### PR DESCRIPTION
in hopes that non-US users get redirected to the storefront that works for them.