### PR TITLE
Fix hyperneon theme secondary button colors to slate gray

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,8 +398,8 @@
         --pico-primary-hover: #ff00e5;
         --pico-primary-hover-background: #ff00e5; /* Electric magenta on hover */
         --pico-primary-hover-border: #ff00e5;
-        --pico-secondary: #7a7a9a; /* Muted gray for outline buttons */
-        --pico-secondary-background: #3a3a5a;
+        --pico-secondary: #8891a4; /* Slate gray for outline buttons (matches X icon) */
+        --pico-secondary-background: #475569; /* Dark slate gray for solid buttons */
         --pico-secondary-hover: #ff00e5; /* Magenta text/border on hover */
         --pico-secondary-hover-background: #ff00e5;
         --pico-secondary-hover-border: #ff00e5;


### PR DESCRIPTION
## Summary
- Replace purple-tinted secondary button colors with slate gray values that match the X close icon and Pico's default palette
- Keeps magenta hover effects unchanged

## Test plan
- [x] Run `uv run pytest tests/test_theme_styles.py -k hyperneon` - all 10 tests pass
- [ ] Navigate to `http://localhost:8000/?theme=hyperneon` and verify Tune/Hamburger buttons show gray (not purple)
- [ ] Verify modal Close buttons have gray background
- [ ] Verify buttons turn magenta on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)