### PR TITLE
Fix data.json preload credentials mismatch warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
       rel="preload"
       href="data.json"
       as="fetch"
+      crossorigin="anonymous"
       type="application/json"
     />
     <link


### PR DESCRIPTION
## Summary
- Add `crossorigin="anonymous"` to the data.json preload link to fix console warnings
- The preload was not being used because the credentials mode didn't match the fetch() call

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Open Chrome DevTools console
- [ ] Confirm the two preload-related warnings are gone:
  - "A preload for data.json is found, but is not used because the request credentials mode does not match"
  - "data.json was preloaded using link preload but not used within a few seconds"

🤖 Generated with [Claude Code](https://claude.com/claude-code)